### PR TITLE
[✨feat]: 공용 API 인스턴스 config 및 인터셉트 설정 추가

### DIFF
--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -65,8 +65,8 @@ const onRequest = (
 
   return config;
 };
-// 요청 인터셉터를 추가한다.
-axiosInstance.interceptors.request.use(onRequest, onError);
+// 인증이 필요하면 요청 인터셉터를 추가한다.
+axiosAuthInstance.interceptors.request.use(onRequest, onError);
 // 응답 인터셉터를 추가한다.
 axiosInstance.interceptors.response.use(onResponse, onError);
 axiosAuthInstance.interceptors.response.use(onResponse, onError);

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -38,10 +38,7 @@ const onResponse = (response: AxiosResponse): AxiosResponse => response.data;
 const onError = (error: AxiosError): Promise<AxiosError> => {
   // 응답 오류가 있을 경우 추가 작업 수행
   if (isAxiosError<ErrorDataType>(error) && error.response) {
-    const errorResponse = error.response;
-
     handleAxiosError(error);
-    console.error(errorResponse.data);
   }
 
   return Promise.reject(error);

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -15,7 +15,7 @@ const headers = {
 
 const axiosConfig = {
   baseURL: import.meta.env.VITE_BASE_API_URL,
-  timeout: 1000, // axios 통신 최대 대기 시간
+  timeout: 10000, // axios 통신 최대 대기 시간
   headers,
 };
 

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -5,7 +5,7 @@ import axios, {
   isAxiosError,
 } from 'axios';
 
-import { CustomInstance, errorData } from '@/types/api';
+import { CustomInstance, ErrorDataType } from '@/types/api';
 
 import handleAxiosError from './handleAxiosError';
 
@@ -37,7 +37,7 @@ const onResponse = (response: AxiosResponse): AxiosResponse => response.data;
  */
 const onError = (error: AxiosError): Promise<AxiosError> => {
   // 응답 오류가 있을 경우 추가 작업 수행
-  if (isAxiosError<errorData>(error) && error.response) {
+  if (isAxiosError<ErrorDataType>(error) && error.response) {
     const errorResponse = error.response;
 
     handleAxiosError(error);
@@ -55,6 +55,7 @@ const onError = (error: AxiosError): Promise<AxiosError> => {
 const onRequest = (
   config: InternalAxiosRequestConfig
 ): InternalAxiosRequestConfig => {
+  // 로컬 스토리지 훅 관련 에러가 있어 일단 대체한다.
   // const accessToken = useLocalStorage('accessToken')[0];
   const accessToken = localStorage.getItem('accessToken');
 

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -1,0 +1,72 @@
+import axios, {
+  AxiosError,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+  isAxiosError,
+} from 'axios';
+
+import { CustomInstance, errorData } from '@/types/api';
+
+import handleAxiosError from './handleAxiosError';
+
+const headers = {
+  'Content-Type': 'application/json',
+};
+
+const axiosConfig = {
+  baseURL: import.meta.env.VITE_BASE_API_URL,
+  timeout: 1000, // axios 통신 최대 대기 시간
+  headers,
+};
+
+export const axiosInstance: CustomInstance = axios.create(axiosConfig);
+export const axiosAuthInstance: CustomInstance = axios.create(axiosConfig);
+
+/**
+ * `response.data`란 코드 형태가 반복 입력해야 하는 것을
+ * 줄여주는 함수이다.
+ * @param response axios 기본 response 객체
+ * @returns response 객체의 data
+ */
+const onResponse = (response: AxiosResponse): AxiosResponse => response.data;
+/**
+ * error를 인터셉트하여 에러 반환 전에 작업을 수행하는 함수이다.
+ * 레퍼런스 : https://axios-http.com/kr/docs/interceptors
+ * @param error axiosError 객체
+ * @returns error 객체 반환
+ */
+const onError = (error: AxiosError): Promise<AxiosError> => {
+  // 응답 오류가 있을 경우 추가 작업 수행
+  if (isAxiosError<errorData>(error) && error.response) {
+    const errorResponse = error.response;
+
+    handleAxiosError(error);
+    console.error(errorResponse.data);
+  }
+
+  return Promise.reject(error);
+};
+/**
+ * 로컬 스토리지에 jwt 토큰이 있을 경우 해당 토큰을
+ * header에 추가하여 새로운 config 객체를 반환하는 함수
+ * @param config 기본 요청 config 객체
+ * @returns jwt 토큰이 있을 경우 header에 추가한 config 객체
+ */
+const onRequest = (
+  config: InternalAxiosRequestConfig
+): InternalAxiosRequestConfig => {
+  // const accessToken = useLocalStorage('accessToken')[0];
+  const accessToken = localStorage.getItem('accessToken');
+
+  if (accessToken) {
+    console.log(accessToken);
+    config.headers.Authorization = `Bearer ${JSON.parse(accessToken)}`;
+  }
+
+  return config;
+};
+// 요청 인터셉터를 추가한다.
+axiosInstance.interceptors.request.use(onRequest, onError);
+// 응답 인터셉터를 추가한다.
+axiosInstance.interceptors.response.use(onResponse, onError);
+axiosAuthInstance.interceptors.response.use(onResponse, onError);

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -60,7 +60,6 @@ const onRequest = (
   const accessToken = localStorage.getItem('accessToken');
 
   if (accessToken) {
-    console.log(accessToken);
     config.headers.Authorization = `Bearer ${JSON.parse(accessToken)}`;
   }
 

--- a/src/services/handleAxiosError.ts
+++ b/src/services/handleAxiosError.ts
@@ -11,10 +11,10 @@ const handleAxiosError = (error: AxiosError<errorData>) => {
 
     switch (errorCode) {
       case 'E00202':
-        console.log('비밀번호가 일치하지 않습니다.');
+        console.error('비밀번호가 일치하지 않습니다.');
         break;
       case 'E01301':
-        console.log('가입되지 않은 이메일입니다.');
+        console.error('가입되지 않은 이메일입니다.');
     }
   }
 };

--- a/src/services/handleAxiosError.ts
+++ b/src/services/handleAxiosError.ts
@@ -11,10 +11,14 @@ const handleAxiosError = (error: AxiosError<ErrorDataType>) => {
 
     switch (errorCode) {
       case 'E00202':
-        console.error('비밀번호가 일치하지 않습니다.');
+        console.log('비밀번호가 일치하지 않습니다.');
         break;
-      case 'E01301':
-        console.error('가입되지 않은 이메일입니다.');
+      case 'E01302':
+        console.log('가입되지 않은 이메일입니다.');
+        break;
+      default:
+        console.error(error);
+        break;
     }
   }
 };

--- a/src/services/handleAxiosError.ts
+++ b/src/services/handleAxiosError.ts
@@ -1,8 +1,8 @@
 import { AxiosError } from 'axios';
 
-import { errorData } from '@/types/api';
+import { ErrorDataType } from '@/types/api';
 
-const handleAxiosError = (error: AxiosError<errorData>) => {
+const handleAxiosError = (error: AxiosError<ErrorDataType>) => {
   const errorData = error.response?.data;
 
   if (errorData) {

--- a/src/services/handleAxiosError.ts
+++ b/src/services/handleAxiosError.ts
@@ -1,0 +1,22 @@
+import { AxiosError } from 'axios';
+
+import { errorData } from '@/types/api';
+
+const handleAxiosError = (error: AxiosError<errorData>) => {
+  const errorData = error.response?.data;
+
+  if (errorData) {
+    const { error } = errorData;
+    const errorCode = error.errorCode;
+
+    switch (errorCode) {
+      case 'E00202':
+        console.log('비밀번호가 일치하지 않습니다.');
+        break;
+      case 'E01301':
+        console.log('가입되지 않은 이메일입니다.');
+    }
+  }
+};
+
+export default handleAxiosError;

--- a/src/services/handleAxiosError.ts
+++ b/src/services/handleAxiosError.ts
@@ -10,6 +10,8 @@ const handleAxiosError = (error: AxiosError<ErrorDataType>) => {
     const errorCode = error.errorCode;
 
     switch (errorCode) {
+      // 에러코드 별로 추가할 수 있다.
+      // Todo: 객체 형태로 키 밸류 형태로 리팩토링한다.
       case 'E00202':
         console.log('비밀번호가 일치하지 않습니다.');
         break;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -16,7 +16,7 @@ export type CustomResponseType<T = unknown> = {
   data?: T;
 };
 
-export interface errorData {
+export interface ErrorDataType {
   success: boolean;
   error: {
     errorCode: string;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,20 @@
+import { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+export interface CustomInstance extends AxiosInstance {
+  get<T>(url: string, config?: AxiosRequestConfig): Promise<T>;
+  post<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T>;
+  delete<T>(url: string, config?: AxiosRequestConfig): Promise<T>;
+}
+
+export type CustomResponseType<T = unknown> = {
+  status: number;
+  data?: T;
+};
+
+export interface errorData {
+  success: boolean;
+  error: {
+    errorCode: string;
+    message: string;
+  };
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -4,6 +4,11 @@ export interface CustomInstance extends AxiosInstance {
   get<T>(url: string, config?: AxiosRequestConfig): Promise<T>;
   post<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T>;
   delete<T>(url: string, config?: AxiosRequestConfig): Promise<T>;
+  patch<T>(
+    url: string,
+    data?: unknown,
+    config?: AxiosRequestConfig
+  ): Promise<T>;
 }
 
 export type CustomResponseType<T = unknown> = {


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->
공용 API 인스턴스 config 및 인터셉트 설정을 추가했습니다.

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가

## 💻 작업 내용

<!-- PR 본문을 입력하세요. -->
- 공용 API 인스턴스 config 파일을 추가했습니다.
- axios interceptors를 사용해 로그인이 필요한 api 호출의 경우 로컬 스토리지의 accessToken을 받아와 header에 추가하도록 설정했습니다.
- axios 관련 타입을 추가했습니다.
  - axios get, post, delete 메서드 타입
  - errorData 타입

## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
- 3차 스프린트부터 api 연동을 다들 시작하실 꺼 같아 급하게 필요한 부분만 axios 인스턴스 기초 설정을 진행했습니다.
- 추가로 변동사항이 있을 수 있습니다. 이후 계속 공유하겠습니다.
- `.env` 파일을 슬랙으로 공유드렸으니 꼭 확인 및 추가 부탁드립니다. 
