### PR TITLE
[🐛fix]: 공용 컴포넌트 Input 스타일 이슈 해결

### DIFF
--- a/src/components/Common/ErrorMessage/ErrorMessage.style.ts
+++ b/src/components/Common/ErrorMessage/ErrorMessage.style.ts
@@ -1,0 +1,21 @@
+import styled, { css } from 'styled-components';
+
+const Wrapper = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 2.4rem;
+`;
+
+const ErrorMessage = styled.span`
+  ${({ theme }) => css`
+    position: absolute;
+    padding: 0 0.2rem;
+    font-size: 1.2rem;
+    color: ${theme.color.red};
+    transform: translateY(0.2rem);
+  `}
+`;
+
+export { ErrorMessage, Wrapper };

--- a/src/components/Common/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/Common/ErrorMessage/ErrorMessage.tsx
@@ -1,0 +1,14 @@
+import { HTMLAttributes } from 'react';
+
+import * as S from './ErrorMessage.style';
+
+export default function ErrorMessage({
+  children,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <S.Wrapper {...props}>
+      <S.ErrorMessage>{children}</S.ErrorMessage>
+    </S.Wrapper>
+  );
+}

--- a/src/components/Common/Input/Input.style.ts
+++ b/src/components/Common/Input/Input.style.ts
@@ -1,48 +1,69 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-import { Col } from '@/styles/GlobalStyle';
+import { Col, Row } from '@/styles/GlobalStyle';
 
-export const InputWrapper = styled(Col)`
+interface InputWrapperProps {
+  $width?: string;
+  $height?: string;
+}
+
+interface InputProps {
+  $isPassword?: boolean;
+  $fontSize?: string;
+  $borderRadius?: string;
+  $borderColor?: string;
+  $backgroundColor?: string;
+  $isError?: boolean;
+}
+
+export const Wrapper = styled(Col)`
   position: relative;
   width: 100%;
 `;
 
 export const LabelText = styled.label`
-  padding: 0 0.2rem 0.5rem;
-  font-size: 1.2rem;
-  color: ${({ theme }) => theme.color.gray_50};
+  ${({ theme }) => css`
+    padding: 0 0.2rem 0.5rem;
+    font-size: 1.2rem;
+    color: ${theme.color.gray_50};
+  `}
 `;
 
-export const BaseInput = styled.input<{ $isError: boolean }>`
-  width: 100%;
-  height: 4.8rem;
-  padding: 0.4rem 1rem;
-  background-color: ${({ theme }) => theme.color.transparent_50};
-  border: ${({ theme, $isError }) =>
-    $isError ? `1px solid ${theme.color.red}` : `none`};
-  border-radius: 0.3rem;
+export const InputWrapper = styled(Row)<InputWrapperProps>`
+  ${({ $width, $height }) => css`
+    position: relative;
+    width: ${$width};
+    height: ${$height};
+  `}
 `;
 
-export const ToggleVisibilityButton = styled.button`
+export const Input = styled.input<InputProps>`
+  ${({
+    $isPassword,
+    $fontSize,
+    $borderRadius,
+    $borderColor,
+    $backgroundColor,
+    $isError,
+    theme,
+  }) => css`
+    width: 100%;
+    padding: 0.4rem ${$isPassword ? '3.4rem' : '1rem'} 0.4rem 1rem;
+    font-size: ${$fontSize};
+    background-color: ${$backgroundColor};
+    border: ${$isError
+      ? `1px solid ${theme.color.red}`
+      : $borderColor
+        ? `1px solid ${$borderColor}`
+        : 'none'};
+    border-radius: ${$borderRadius};
+  `}
+`;
+
+export const ToggleButtonWrapper = styled.button`
   position: absolute;
-  top: 3.4rem;
+  top: 50%;
   right: 0.2rem;
   padding: 0 0.8rem;
-  background-color: transparent;
-`;
-
-export const InputErrorWrapper = styled.div`
-  position: relative;
-  display: flex;
-  align-items: center;
-  width: 100%;
-  height: 2.4rem;
-`;
-
-export const InputErrorMessage = styled.span`
-  position: absolute;
-  padding: 0 0.2rem;
-  font-size: 1.2rem;
-  color: ${({ theme }) => theme.color.red};
-  transform: translateY(0.2rem);
+  transform: translateY(calc(-50% + 0.2rem));
 `;

--- a/src/components/Common/Input/Input.tsx
+++ b/src/components/Common/Input/Input.tsx
@@ -1,6 +1,6 @@
 import VisibilityOffRoundedIcon from '@mui/icons-material/VisibilityOffRounded';
 import VisibilityRoundedIcon from '@mui/icons-material/VisibilityRounded';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { FieldValues } from 'react-hook-form';
 
 import { useCustomTheme } from '@/hooks/useCustomTheme';
@@ -53,10 +53,7 @@ export default function Input<T extends FieldValues>({
 
   const inputError = formState?.errors[name];
   const inputErrorMessage = inputError && (inputError.message as string);
-
-  useEffect(() => {
-    setInputType(type);
-  }, [type]);
+  const isDirty = formState?.isDirty;
 
   return (
     <S.Wrapper>
@@ -67,7 +64,6 @@ export default function Input<T extends FieldValues>({
       >
         <S.Input
           id={name}
-          type={inputType}
           autoComplete="true"
           $isPassword={type === 'password'}
           $isError={!!inputErrorMessage}
@@ -81,7 +77,7 @@ export default function Input<T extends FieldValues>({
           })}
           {...props}
         />
-        {type === 'password' && (
+        {type === 'password' && isDirty && (
           <S.ToggleButtonWrapper
             type="button"
             tabIndex={-1}

--- a/src/components/Common/Input/Input.tsx
+++ b/src/components/Common/Input/Input.tsx
@@ -1,19 +1,13 @@
 import VisibilityOffRoundedIcon from '@mui/icons-material/VisibilityOffRounded';
 import VisibilityRoundedIcon from '@mui/icons-material/VisibilityRounded';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FieldValues } from 'react-hook-form';
 
 import { useCustomTheme } from '@/hooks/useCustomTheme';
 import { InputProps } from '@/types/input';
 
-import {
-  BaseInput,
-  InputErrorMessage,
-  InputErrorWrapper,
-  InputWrapper,
-  LabelText,
-  ToggleVisibilityButton,
-} from './Input.style';
+import ErrorMessage from '../ErrorMessage/ErrorMessage';
+import * as S from './Input.style';
 
 /**
  * react-hook-form을 사용하는 공용 Input 컴포넌트
@@ -24,6 +18,12 @@ import {
  * @param type - optional) text | email | password. default = text
  * @param formState - optional) validate 필요 시 사용. useForm의 formState
  * @param validation - optional) validate 필요 시 사용. validate 패턴과 errorMessage를 지정
+ * @param width - optional) default = 100%
+ * @param height - optional) default = 4.8rem
+ * @param fontSize - optional) default = 1.6rem
+ * @param borderRadius - optional) default = round
+ * @param borderColor - optional) default = none
+ * @param backgroundColor - optional) default = transparent_50
  */
 export default function Input<T extends FieldValues>({
   name,
@@ -33,6 +33,12 @@ export default function Input<T extends FieldValues>({
   type = 'text',
   formState,
   validation,
+  width = '100%',
+  height = '4.8rem',
+  fontSize = '1.6rem',
+  borderRadius,
+  borderColor,
+  backgroundColor,
   ...props
 }: InputProps<T>) {
   const { theme } = useCustomTheme();
@@ -49,40 +55,47 @@ export default function Input<T extends FieldValues>({
   const inputErrorMessage = inputError && (inputError.message as string);
 
   return (
-    <InputWrapper>
-      {label && <LabelText htmlFor={name}>{label}</LabelText>}
-      <BaseInput
-        type={inputType}
-        {...register(name, {
-          ...validation,
-          required: required && '값이 입력되지 않았어요',
-        })}
-        autoComplete="true"
-        $isError={!!inputErrorMessage}
-        {...props}
-      />
-      {type === 'password' && (
-        <ToggleVisibilityButton
-          type="button"
-          tabIndex={-1}
-          onClick={handleToggleType}
-        >
-          {isPasswordType ? (
-            <VisibilityRoundedIcon
-              sx={{ width: 20, height: 20, color: theme.color.gray_50 }}
-            />
-          ) : (
-            <VisibilityOffRoundedIcon
-              sx={{ width: 20, height: 20, color: theme.color.gray_50 }}
-            />
-          )}
-        </ToggleVisibilityButton>
-      )}
-      {inputErrorMessage && (
-        <InputErrorWrapper>
-          <InputErrorMessage>{inputErrorMessage}</InputErrorMessage>
-        </InputErrorWrapper>
-      )}
-    </InputWrapper>
+    <S.Wrapper>
+      {label && <S.LabelText htmlFor={name}>{label}</S.LabelText>}
+      <S.InputWrapper
+        $width={width}
+        $height={height}
+      >
+        <S.Input
+          id={name}
+          type={inputType}
+          autoComplete="true"
+          $isPassword={type === 'password'}
+          $isError={!!inputErrorMessage}
+          $fontSize={fontSize}
+          $borderRadius={borderRadius || theme.shape.round}
+          $borderColor={borderColor}
+          $backgroundColor={backgroundColor || theme.color.transparent_50}
+          {...register(name, {
+            ...validation,
+            required: required && '값이 입력되지 않았어요',
+          })}
+          {...props}
+        />
+        {type === 'password' && (
+          <S.ToggleButtonWrapper
+            type="button"
+            tabIndex={-1}
+            onClick={handleToggleType}
+          >
+            {isPasswordType ? (
+              <VisibilityRoundedIcon
+                sx={{ width: 20, height: 20, color: theme.color.gray_50 }}
+              />
+            ) : (
+              <VisibilityOffRoundedIcon
+                sx={{ width: 20, height: 20, color: theme.color.gray_50 }}
+              />
+            )}
+          </S.ToggleButtonWrapper>
+        )}
+      </S.InputWrapper>
+      {inputErrorMessage && <ErrorMessage>{inputErrorMessage}</ErrorMessage>}
+    </S.Wrapper>
   );
 }

--- a/src/components/Common/Input/Input.tsx
+++ b/src/components/Common/Input/Input.tsx
@@ -54,6 +54,10 @@ export default function Input<T extends FieldValues>({
   const inputError = formState?.errors[name];
   const inputErrorMessage = inputError && (inputError.message as string);
 
+  useEffect(() => {
+    setInputType(type);
+  }, [type]);
+
   return (
     <S.Wrapper>
       {label && <S.LabelText htmlFor={name}>{label}</S.LabelText>}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,7 @@ export { default as Button } from './Common/Button/Button';
 export { default as CheckBox } from './Common/CheckBox/CheckBox';
 export { DropDown, MultiDropDown } from './Common/DropDown';
 export { default as EllipsisText } from './Common/EllipsisText/EllipsisText';
+export { default as ErrorMessage } from './Common/ErrorMessage/ErrorMessage';
 export { default as Header } from './Common/Header/Header';
 export { default as Icon } from './Common/Icon/Icon';
 export { default as Image } from './Common/Image/Image';

--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -15,10 +15,19 @@ export interface InputProps<T extends FieldValues>
   required?: boolean;
   formState?: FormState<T>;
   validation?: RegisterOptions;
+  width?: string;
+  height?: string;
+  fontSize?: string;
+  borderRadius?: string;
+  borderColor?: string;
+  backgroundColor?: string;
 }
 
 export interface InputListType<T extends FieldValues>
-  extends Omit<InputProps<T>, 'register' | 'errors'> {
+  extends Pick<
+    InputProps<T>,
+    'name' | 'label' | 'type' | 'required' | 'formState' | 'validation'
+  > {
   guide?: React.ReactNode;
 }
 


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->

Input 컴포넌트를 더 다양한 화면에서 사용하기 위해 스타일링 props를 추가합니다.
어긋나는 레이아웃을 수정했습니다.


## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링

## 💻 작업 내용

<!-- PR 본문을 입력하세요. -->

- ErrrorMessage 컴포넌트 Common 폴더로 분리 (Input 외 컴포넌트에서 에러를 표시할 때 사용하기 위함)
- Input 스타일링 props 추가
- Password Toggle 버튼 위치 정중앙으로 변경
- Password Toggle 버튼 글자와 겹치는 문제 해결
- 내용 미입력시 password 토글 버튼이 보여지지 않도록 수정

## 🧪 예제 코드
<details>
<summary><b>Password Input</b></summary>
<div>

```tsx
// src/pages/WelcomePage.tsx

import { SubmitHandler, useForm } from 'react-hook-form';

import { Input } from '@/components';
import { useCustomTheme } from '@/hooks/useCustomTheme';

interface DataTypes {
  password: string;
}

export default function WelcomePage() {
  const { theme } = useCustomTheme();

  const { register, handleSubmit, formState } = useForm<DataTypes>({
    mode: 'onChange',
  });

  const onSubmit: SubmitHandler<DataTypes> = data => {
    console.log('submit data: ', data);
  };

  const SubmitButton = () => (
    <button
      style={{
        width: '100%',
        color: '#fff',
        borderRadius: '0.4rem',
        backgroundColor: theme.color.gray_50,
        marginTop: '1rem',
        padding: '1rem',
      }}
    >
      검색하기
    </button>
  );

  return (
    <form
      onSubmit={handleSubmit(onSubmit)}
      style={{ padding: '20px' }}
    >
      <Input
        name="password"
        label="비밀번호"
        type="password"
        register={register}
        formState={formState}
        validation={{
          minLength: {
            value: 8,
            message: '최소 8자리 이상 입력해 주세요.',
          },
        }}
      />
      <SubmitButton />
    </form>
  );
}


```
</div>
</details>



## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->

### 1. 토글 버튼과 글자가 겹치는 문제 개선

<img width="285" alt="스크린샷 2024-02-27 오후 6 23 25" src="https://github.com/1e5i-Shark/algobaro-fe/assets/55135881/7c4b4eeb-d804-403e-a9fa-af01e0addc1b">

<img width="293" alt="스크린샷 2024-02-27 오후 6 23 51" src="https://github.com/1e5i-Shark/algobaro-fe/assets/55135881/20327142-1cac-4450-9a4f-fd0b6a4db238">

<br />

### 2. 토글 버튼이 정중앙에 오지 않는 문제 개선

**<라벨이 있는 경우>**

<img width="562" alt="스크린샷 2024-02-27 오후 6 11 32" src="https://github.com/1e5i-Shark/algobaro-fe/assets/55135881/cfe1eff2-8dc8-4484-a73a-6a2eda247c31">
<img width="565" alt="스크린샷 2024-02-27 오후 6 11 09" src="https://github.com/1e5i-Shark/algobaro-fe/assets/55135881/8fe081c4-b313-4531-8036-8cf59b11a287">

**<라벨이 없는 경우>**
<img width="565" alt="스크린샷 2024-02-27 오후 6 12 26" src="https://github.com/1e5i-Shark/algobaro-fe/assets/55135881/371f800a-2b55-47e9-995f-2c6584eee59d">
<img width="566" alt="스크린샷 2024-02-27 오후 6 13 00" src="https://github.com/1e5i-Shark/algobaro-fe/assets/55135881/e2cea1f3-5ba6-4813-a742-64db231d1cd9">

### 3. Input Props 추가

아래의 스타일링 props를 추가하고 스타일링 컨벤션으로 리팩토링을 했습니다!

```
/**
 * react-hook-form을 사용하는 공용 Input 컴포넌트
 * @param width - optional) default = 100%
 * @param height - optional) default = 4.8rem
 * @param fontSize - optional) default = 1.6rem
 * @param borderRadius - optional) default = round
 * @param borderColor - optional) default = none
 * @param backgroundColor - optional) default = transparent_50
 */
```

### 4. 추가 수정 사항

- [x] label과의 연동 위해 Input의 id값 추가
- [x] isDirty 상태를 이용하여 미입력시 password 토글 버튼이 보여지지 않도록 수정
    - **password input인 경우 defaultValue를 설정해주셔야 정상 동작합니다!**

컨벤션이 지켜지지 않은 부분이 있다면 피드백 부탁드리겠습니다!