### PR TITLE
[🐛fix]: axiosInstance 파일 내 로컬 스토리지 JSON 파싱 취소 및 일부 수정사항 적용

### DIFF
--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -13,14 +13,15 @@ const headers = {
   'Content-Type': 'application/json',
 };
 
-const axiosConfig = {
+const axiosCustomConfig = {
   baseURL: import.meta.env.VITE_BASE_API_URL,
   timeout: 10000, // axios 통신 최대 대기 시간
   headers,
 };
 
-export const axiosInstance: CustomInstance = axios.create(axiosConfig);
-export const axiosAuthInstance: CustomInstance = axios.create(axiosConfig);
+export const axiosInstance: CustomInstance = axios.create(axiosCustomConfig);
+export const axiosAuthInstance: CustomInstance =
+  axios.create(axiosCustomConfig);
 
 /**
  * `response.data`란 코드 형태가 반복 입력해야 하는 것을

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -53,11 +53,10 @@ const onRequest = (
   config: InternalAxiosRequestConfig
 ): InternalAxiosRequestConfig => {
   // 로컬 스토리지 훅 관련 에러가 있어 일단 대체한다.
-  // const accessToken = useLocalStorage('accessToken')[0];
   const accessToken = localStorage.getItem('accessToken');
 
   if (accessToken) {
-    config.headers.Authorization = `Bearer ${JSON.parse(accessToken)}`;
+    config.headers.Authorization = `Bearer ${accessToken}`;
   }
 
   return config;


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->
axiosInstance 파일 내 로컬 스토리지 JSON 파싱 취소 및 일부 수정사항을 적용했습니다.

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 코드 리팩토링
- [x] 에러 이슈 fix


## 💻 작업 내용

<!-- PR 본문을 입력하세요. -->
- axiosInstance 내 `onRequest` 함수에서 `accessToken`을 로컬 스토리지로부터 받아올 때 JSON 파싱 로직을 제거했습니다.
  - 기존에 string으로 받아오기 때문에 에러가 발생했기에 수정했습니다.

- useLocalStorage 훅 사용 코드에 대한 주석을 제거했습니다.
  - 훅은 컴포넌트 내부 최상단에서 사용이 가능한데 axiosInstance 파일은 컴포넌트가 없으므로 사용이 불가능한 것 같습니다.

- `axiosCustomConfig`로 변수명 변경
  - 커스텀한 axios 설정이기 때문에 네이밍을 변경했습니다.
  
## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
- 추가적인 변경 사항이 있다면 알려주세요.
