### PR TITLE
[♻️refactor]: signIn 함수에 대한 useMutation 훅(useAuth) 구현 리팩토링

### DIFF
--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
+import { LOCAL_ACCESSTOKEN } from '@/constants/localStorageKey';
 import { useSignIn } from '@/hooks/Api/useAuth';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { PATH } from '@/routes/path';
@@ -26,7 +27,7 @@ interface LoginInfo {
 
 export default function LoginForm({ width = '100%' }: { width?: string }) {
   // 저장된 accessToken
-  const [accessToken] = useLocalStorage('accessToken');
+  const [accessToken] = useLocalStorage(LOCAL_ACCESSTOKEN);
   // 저장한 이메일 아이디
   const [saveEmail, setSaveEmail] = useLocalStorage('saveEmail');
   // 아이디 저장 옵션 여부

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -21,8 +21,8 @@ import {
 } from './LoginForm.style';
 
 interface LoginInfo {
-  loginEmail: string;
-  loginPassword: string;
+  email: string;
+  password: string;
 }
 
 export default function LoginForm({ width = '100%' }: { width?: string }) {
@@ -37,8 +37,8 @@ export default function LoginForm({ width = '100%' }: { width?: string }) {
     mode: 'onChange',
     defaultValues: {
       // 아이디 저장한 것을 기본값으로 불러온다.
-      loginEmail: saveEmail ? saveEmail : '',
-      loginPassword: '',
+      email: saveEmail ? saveEmail : '',
+      password: '',
     },
   });
   // signIn api mutate 훅
@@ -49,7 +49,7 @@ export default function LoginForm({ width = '100%' }: { width?: string }) {
   const inputPropsList: InputListProps<LoginInfo> = [
     {
       label: '이메일',
-      name: 'loginEmail',
+      name: 'email',
       type: 'email',
       placeholder: 'algo@email.com',
       required: true,
@@ -57,7 +57,7 @@ export default function LoginForm({ width = '100%' }: { width?: string }) {
     },
     {
       label: '비밀번호',
-      name: 'loginPassword',
+      name: 'password',
       type: 'password',
       required: true,
       placeholder: '비밀번호',
@@ -68,8 +68,8 @@ export default function LoginForm({ width = '100%' }: { width?: string }) {
   const onSubmitData: SubmitHandler<LoginInfo> = async data => {
     // 아이디 저장 체크 시 로컬 스토리지에 저장
     // 해제 시 초기화
-    const { loginEmail } = data;
-    setSaveEmail(isSaveEmail ? loginEmail : '');
+    const { email } = data;
+    setSaveEmail(isSaveEmail ? email : '');
 
     // api를 호출하고 인증 성공 시 토큰을 로컬 스토리지에 저장한다.
     // 이후 메인 페이지(홈)으로 다이렉팅한다.

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -25,6 +25,8 @@ interface LoginInfo {
 }
 
 export default function LoginForm({ width = '100%' }: { width?: string }) {
+  // 저장된 accessToken
+  const [accessToken] = useLocalStorage('accessToken');
   // 저장한 이메일 아이디
   const [saveEmail, setSaveEmail] = useLocalStorage('saveEmail');
   // 아이디 저장 옵션 여부
@@ -82,41 +84,45 @@ export default function LoginForm({ width = '100%' }: { width?: string }) {
   };
 
   return (
-    <LoginFormWrapper width={width}>
-      <LoginFormContainer onSubmit={handleSubmit(onSubmitData)}>
-        {/* 로그인 정보 입력 영역 */}
-        <LoginInputContainer>
-          {inputPropsList.map(props => {
-            return (
-              <LoginInputItem key={props.name}>
-                <Input
-                  register={register}
-                  formState={formState}
-                  {...props}
-                />
-              </LoginInputItem>
-            );
-          })}
-        </LoginInputContainer>
-        {/* 로그인 버튼 */}
-        <LoginButton
-          type="submit"
-          disabled={isValid ? false : true}
-        >
-          로그인
-        </LoginButton>
-        {/* 로그인 정보 외 설정 및 링크 영역 */}
-        <LoginOptionContainer>
-          <CheckBox
-            label="아이디 저장"
-            onChange={handleChangeCheck}
-            checked={isSaveEmail}
-          />
-          <SignUpTextLink to={PATH.SIGNUP}>
-            아직 회원가입을 안하셨나요?
-          </SignUpTextLink>
-        </LoginOptionContainer>
-      </LoginFormContainer>
-    </LoginFormWrapper>
+    <>
+      {!accessToken ? (
+        <LoginFormWrapper width={width}>
+          <LoginFormContainer onSubmit={handleSubmit(onSubmitData)}>
+            {/* 로그인 정보 입력 영역 */}
+            <LoginInputContainer>
+              {inputPropsList.map(props => {
+                return (
+                  <LoginInputItem key={props.name}>
+                    <Input
+                      register={register}
+                      formState={formState}
+                      {...props}
+                    />
+                  </LoginInputItem>
+                );
+              })}
+            </LoginInputContainer>
+            {/* 로그인 버튼 */}
+            <LoginButton
+              type="submit"
+              disabled={isValid ? false : true}
+            >
+              로그인
+            </LoginButton>
+            {/* 로그인 정보 외 설정 및 링크 영역 */}
+            <LoginOptionContainer>
+              <CheckBox
+                label="아이디 저장"
+                onChange={handleChangeCheck}
+                checked={isSaveEmail}
+              />
+              <SignUpTextLink to={PATH.SIGNUP}>
+                아직 회원가입을 안하셨나요?
+              </SignUpTextLink>
+            </LoginOptionContainer>
+          </LoginFormContainer>
+        </LoginFormWrapper>
+      ) : null}
+    </>
   );
 }

--- a/src/constants/localStorageKey.ts
+++ b/src/constants/localStorageKey.ts
@@ -1,0 +1,1 @@
+export const LOCAL_ACCESSTOKEN = 'accessToken';

--- a/src/hooks/Api/type.ts
+++ b/src/hooks/Api/type.ts
@@ -1,4 +1,4 @@
 export interface SignInProps {
-  loginEmail: string;
-  loginPassword: string;
+  email: string;
+  password: string;
 }

--- a/src/hooks/Api/type.ts
+++ b/src/hooks/Api/type.ts
@@ -1,0 +1,4 @@
+export interface SignInProps {
+  loginEmail: string;
+  loginPassword: string;
+}

--- a/src/hooks/Api/useAuth.ts
+++ b/src/hooks/Api/useAuth.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
+import { LOCAL_ACCESSTOKEN } from '@/constants/localStorageKey';
 import { PATH } from '@/routes/path';
 import { signIn } from '@/services/Auth';
 
@@ -15,7 +16,7 @@ import { SignInProps } from './type';
  */
 export const useSignIn = () => {
   const navigate = useNavigate();
-  const [, setAccessToken] = useLocalStorage('accessToken');
+  const [, setAccessToken] = useLocalStorage(LOCAL_ACCESSTOKEN);
 
   return useMutation({
     mutationFn: ({ loginEmail, loginPassword }: SignInProps) => {

--- a/src/hooks/Api/useAuth.ts
+++ b/src/hooks/Api/useAuth.ts
@@ -19,8 +19,8 @@ export const useSignIn = () => {
   const [, setAccessToken] = useLocalStorage(LOCAL_ACCESSTOKEN);
 
   return useMutation({
-    mutationFn: ({ loginEmail, loginPassword }: SignInProps) => {
-      return signIn(loginEmail, loginPassword);
+    mutationFn: ({ email, password }: SignInProps) => {
+      return signIn(email, password);
     },
     onSuccess: ({ response }) => {
       setAccessToken(response.accessToken);

--- a/src/hooks/Api/useAuth.ts
+++ b/src/hooks/Api/useAuth.ts
@@ -6,22 +6,18 @@ import { PATH } from '@/routes/path';
 import { signIn } from '@/services/Auth';
 
 import { useLocalStorage } from '../useLocalStorage';
-import { SignInProps } from './type';
 
 /**
- * 로그인 signIn API 통신 함수를 사용하는 useMutation 훅이다.
+ * 로그인 signIn API 통신 함수를 사용하는 useMutation를 반환하는 훅이다.
  * - 로그인 성공 시 액세스 토큰을 로컬 스토리지에 저장한다.
  * - 저장 후 메인 페이지(홈)으로 다이렉팅한다.
- * @returns `mutate`, `data`
  */
 export const useSignIn = () => {
   const navigate = useNavigate();
   const [, setAccessToken] = useLocalStorage(LOCAL_ACCESSTOKEN);
 
   return useMutation({
-    mutationFn: ({ email, password }: SignInProps) => {
-      return signIn(email, password);
-    },
+    mutationFn: signIn,
     onSuccess: ({ response }) => {
       setAccessToken(response.accessToken);
       navigate(PATH.HOME);

--- a/src/hooks/Api/useAuth.ts
+++ b/src/hooks/Api/useAuth.ts
@@ -1,0 +1,31 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { PATH } from '@/routes/path';
+import { signIn } from '@/services/Auth';
+
+import { useLocalStorage } from '../useLocalStorage';
+import { SignInProps } from './type';
+
+/**
+ * 로그인 signIn API 통신 함수를 사용하는 useMutation 훅이다.
+ * - 로그인 성공 시 액세스 토큰을 로컬 스토리지에 저장한다.
+ * - 저장 후 메인 페이지(홈)으로 다이렉팅한다.
+ * @returns `mutate`, `data`
+ */
+export const useSignIn = () => {
+  const navigate = useNavigate();
+  const [, setAccessToken] = useLocalStorage('accessToken');
+
+  const { mutate, data } = useMutation({
+    mutationFn: ({ loginEmail, loginPassword }: SignInProps) => {
+      return signIn(loginEmail, loginPassword);
+    },
+    onSuccess: ({ response }) => {
+      setAccessToken(response.accessToken);
+      navigate(PATH.HOME);
+    },
+  });
+
+  return { mutate, data };
+};

--- a/src/hooks/Api/useAuth.ts
+++ b/src/hooks/Api/useAuth.ts
@@ -17,7 +17,7 @@ export const useSignIn = () => {
   const navigate = useNavigate();
   const [, setAccessToken] = useLocalStorage('accessToken');
 
-  const { mutate, data } = useMutation({
+  return useMutation({
     mutationFn: ({ loginEmail, loginPassword }: SignInProps) => {
       return signIn(loginEmail, loginPassword);
     },
@@ -26,6 +26,4 @@ export const useSignIn = () => {
       navigate(PATH.HOME);
     },
   });
-
-  return { mutate, data };
 };

--- a/src/routes/CheckUserLogin.ts
+++ b/src/routes/CheckUserLogin.ts
@@ -1,5 +1,7 @@
+import { LOCAL_ACCESSTOKEN } from '@/constants/localStorageKey';
+
 export const CheckUserLogin = () => {
   // 유저가 로그인 했는지 검사하는 로직
-  const accessToken = localStorage.getItem('accessToken');
+  const accessToken = localStorage.getItem(LOCAL_ACCESSTOKEN);
   return accessToken;
 };

--- a/src/services/Auth/signIn.ts
+++ b/src/services/Auth/signIn.ts
@@ -1,3 +1,5 @@
+import { SignInProps } from '@/hooks/Api/type';
+
 import { SIGNIN_URL } from '../apiEndpoint';
 import { axiosInstance } from '../axiosInstance';
 
@@ -8,7 +10,7 @@ interface SignInResponse {
   };
 }
 
-const signIn = async (email: string, password: string) => {
+const signIn = async ({ email, password }: SignInProps) => {
   const reqBody = {
     email,
     password,

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -5,6 +5,7 @@ import axios, {
   isAxiosError,
 } from 'axios';
 
+import { LOCAL_ACCESSTOKEN } from '@/constants/localStorageKey';
 import { CustomInstance, ErrorDataType } from '@/types/api';
 
 import handleAxiosError from './handleAxiosError';
@@ -54,7 +55,7 @@ const onRequest = (
   config: InternalAxiosRequestConfig
 ): InternalAxiosRequestConfig => {
   // 로컬 스토리지 훅 관련 에러가 있어 일단 대체한다.
-  const accessToken = localStorage.getItem('accessToken');
+  const accessToken = localStorage.getItem(LOCAL_ACCESSTOKEN);
 
   if (accessToken) {
     config.headers.Authorization = `Bearer ${accessToken}`;


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->
로그인 `signIn` 함수에 대한 useMutation 훅인 `useAuth`를 구현하고 일부 렌더링 로직을 리팩토링했습니다.

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링


## 💻 작업 내용

<!-- PR 본문을 입력하세요. -->
- `useSignIn` : `signIn` 함수에 대한 useMutation 훅 구현 및 적용 (https://github.com/1e5i-Shark/algobaro-fe/commit/87f9df6157032dd53f3cfc30b1bbae6390c6018a, https://github.com/1e5i-Shark/algobaro-fe/commit/3cf18c46aed630eba2e1f6279e9fa9a8d316406c)
  - `useAuth` 훅 내부에 위치시켜서 이후 인증 관련 기능인 `useSignUp`과 같은 추가 훅에 대한 확장성도 고려했습니다.

- 로그인 상태에서는 로그인 폼이 렌더링되지 않도록 수정했습니다.(https://github.com/1e5i-Shark/algobaro-fe/commit/fb51994263cca820b0f2d63136b1389253c705ea)
## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
- 훅의 디렉터리 구조나 네이밍이 바람직한지 궁금합니다.
- react query를 적용해보긴 했는데 이 방식이 맞는지 검토 부탁드립니다.
- 시작페이지에 대한 레이아웃 디자인 수정은 따로 issue를 생성해서 작업하겠습니다.
