### PR TITLE
[🐛fix]: 기존 Modal 공통 컴포넌트 버그 해결 및 업그레이드

### DIFF
--- a/src/components/Common/Input/Input.tsx
+++ b/src/components/Common/Input/Input.tsx
@@ -80,7 +80,7 @@ export default function Input<T extends FieldValues>({
           })}
           {...props}
         />
-        {type === 'password' && isDirty && (
+        {type === 'password' && (
           <S.ToggleButtonWrapper
             type="button"
             tabIndex={-1}

--- a/src/components/Common/Modal/Modal.style.ts
+++ b/src/components/Common/Modal/Modal.style.ts
@@ -16,8 +16,8 @@ export const ModalWrapper = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
   `}
 `;
 

--- a/src/components/Common/Modal/Modal.style.ts
+++ b/src/components/Common/Modal/Modal.style.ts
@@ -1,5 +1,5 @@
 import { HTMLAttributes } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 interface ModalContainerProps extends HTMLAttributes<HTMLDivElement> {
   width: string;
@@ -8,14 +8,17 @@ interface ModalContainerProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export const ModalWrapper = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100vw;
-  height: 100vh;
+  ${({ theme }) => css`
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: ${theme.ZINDEX.MODAL};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100vw;
+    height: 100vh;
+  `}
 `;
 
 export const ModalBackground = styled.div`

--- a/src/components/Common/Modal/Modal.tsx
+++ b/src/components/Common/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
-import { forwardRef, HTMLAttributes } from 'react';
+import { forwardRef, HTMLAttributes, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
 import {
@@ -41,6 +41,13 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
     },
     ref
   ) => {
+    // modal이 떠 있을 땐 스크롤 막음
+    // modal 닫히면 다시 스크롤 가능하도록 함
+    useEffect(() => {
+      document.body.style.overflow = isOpen ? 'hidden' : '';
+      document.documentElement.style.height = isOpen ? '100vh' : '';
+    }, [isOpen]);
+
     return createPortal(
       isOpen ? (
         <ModalWrapper ref={ref}>

--- a/src/components/Common/Modal/Modal.tsx
+++ b/src/components/Common/Modal/Modal.tsx
@@ -44,19 +44,21 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
     return createPortal(
       isOpen ? (
         <ModalWrapper ref={ref}>
-          <ModalBackground onClick={onClose} />
+          <ModalBackground onClick={mode === 'normal' ? onClose : undefined} />
           <ModalContainer
             width={width}
             height={height}
             $borderRadius={borderRadius}
             {...props}
           >
-            <ModalCloseButton
-              $coordinate={borderRadius}
-              onClick={onClose}
-            >
-              <CloseRoundedIcon />
-            </ModalCloseButton>
+            {mode === 'normal' ? (
+              <ModalCloseButton
+                $coordinate={borderRadius}
+                onClick={onClose}
+              >
+                <CloseRoundedIcon />
+              </ModalCloseButton>
+            ) : null}
             <ModalContent>{children}</ModalContent>
           </ModalContainer>
         </ModalWrapper>

--- a/src/components/Common/Modal/Modal.tsx
+++ b/src/components/Common/Modal/Modal.tsx
@@ -11,6 +11,7 @@ import {
 } from './Modal.style';
 
 interface ModalProps extends HTMLAttributes<HTMLDivElement> {
+  mode?: 'normal' | 'confirm';
   width?: string;
   height?: string;
   borderRadius?: string;
@@ -30,6 +31,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
   (
     {
       children,
+      mode = 'normal',
       width = '50%',
       height = '50%',
       borderRadius = '1.5rem',

--- a/src/pages/WelcomePage/WelcomePage.tsx
+++ b/src/pages/WelcomePage/WelcomePage.tsx
@@ -72,8 +72,8 @@ export default function WelcomePage() {
             })}
           </S.MainSubList>
         </S.MainLeftContainer>
-        <S.MainRightContainer style={{ width: `${myNickName ? '25%' : ''}` }}>
-          {myNickName ? (
+        {accessToken && myNickName ? (
+          <S.MainRightContainer style={{ width: `${myNickName ? '25%' : ''}` }}>
             <>
               <S.UserNameContainer>
                 <S.UserNickName>{myNickName}</S.UserNickName> 님
@@ -83,8 +83,8 @@ export default function WelcomePage() {
                 <ArrowForwardIosRoundedIcon />
               </Button>
             </>
-          ) : null}
-        </S.MainRightContainer>
+          </S.MainRightContainer>
+        ) : null}
         <LoginForm width="25%" />
       </S.MainContainer>
       <S.MoreDetailContainer>


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->
기존 Modal 공통 컴포넌트의 버그를 해결하고 모드를 추가해 업그레이드했습니다.

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가
- [x] 코드 리팩토링


## 💻 작업 내용
#### 테스트 코드
<details>
<summary>HomePage.tsx</summary>
<div>

```ts
import { useState } from 'react';

import { Button, Modal } from '@/components';
import { Row } from '@/styles/GlobalStyle';

export default function HomePage() {
  const [isOpen, setIsOpen] = useState(false);

  const handleOk = () => {
    setIsOpen(false);
  };

  const handleOpenModal = () => {
    setIsOpen(true);
  };

  const handleCloseModal = () => {
    setIsOpen(false);
  };
  return (
    <div>
      <Modal
        mode="confirm"
        isOpen={isOpen}
        onClose={handleCloseModal}
      >
        <h1>확인하셨죠?</h1>
        <Row style={{ gap: '1rem' }}>
          <Button onClick={handleOk}>확인</Button>
          <Button onClick={handleCloseModal}>취소</Button>
        </Row>
      </Modal>
      <Button onClick={handleOpenModal}>모달 오픈</Button>
      HomePage
      <div
        style={{
          height: '150vh',
          backgroundColor: 'yellowgreen',
        }}
      ></div>
    </div>
  );
}

```

</div>
</details>



<!-- PR 본문을 입력하세요. -->

#### 모달 컴포넌트 변경 사항
- 확인 모달 모드 추가
  - `mode` props를 추가해서 선택할 수 있게 했습니다. (https://github.com/1e5i-Shark/algobaro-fe/commit/1fdb1a4efbdece159282fc34b114081ce2ecdfdc)
    - 기본값은 'normal`입니다.
  - 'confirm` 모드일 때는 닫기 x 버튼을 숨기고 외부 배경 overlay에 대한 클릭 이벤트를 제거했습니다. (https://github.com/1e5i-Shark/algobaro-fe/commit/1a6075b35125d2fb67cf43e0e4aa9b82bc8dbd13)
    - 확인 모달 내부의 디자인은 사용할 때마다 달라질 수 있으므로 `children`을 통해 사용하는 쪽에서 따로 구현할 수 있도록 자유도를 줬습니다.
    - 기본적인 확인 및 취소 버튼 이벤트 props 넘기는 방법은 테스트 코드를 참고하시면 될 것 같습니다.
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/71a37a2f-5324-4056-8a16-ef85179ec43a)

- 모달의 `z-index`를 추가했습니다. (https://github.com/1e5i-Shark/algobaro-fe/commit/c1d8430314872c38352a4a55859d98ffe30b26b3)
- ModalWrapper의 높이와 너비를 `100%`로 변경했습니다. (https://github.com/1e5i-Shark/algobaro-fe/commit/6638c021999b741c65246f2bb6030f91d6c11c6e)
- 모달 외부의 스크롤을 방지하는 기능을 추가했습니다. (https://github.com/1e5i-Shark/algobaro-fe/commit/2a8acf15b127451560077afb343aab717dc545dd)

#### 모달 컴포넌트 이외 추가 수정사항
- Input 공용 컴포넌트의 타입이 password일 경우 눈모양 아이콘이 항상 보이도록 수정했습니다. (https://github.com/1e5i-Shark/algobaro-fe/commit/1b1094e88dc9591cb6c3bd11d3ca4da41698fcbb)
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/40f3a3e8-b531-4df9-a24f-de8849d74f0a)


## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
- 작업 내용에 포함된 기능들이 제대로 동작하는지 각자 PC에서 테스트 부탁드립니다!