### PR TITLE
[✨feat]: Pagination 공통 컴포넌트 구현

### DIFF
--- a/src/components/Common/Pagination/Pagination.tsx
+++ b/src/components/Common/Pagination/Pagination.tsx
@@ -55,6 +55,23 @@ export default function Pagination({
               backgroundColor: selectedBgColor || theme.color.secondary_color,
               color: selectedTextColor || theme.color.background_primary,
             },
+            // 다크 모드 ) 선택된 페이지에서, 호버시 배경색(분홍색)이 사라지는 문제 해결
+            '& .MuiPaginationItem-page.Mui-selected:hover': {
+              backgroundColor: selectedBgColor || theme.color.secondary_color,
+            },
+            // // 미선택된 페이지에서, 호버시 나타나는 배경색 설정
+            '& .MuiPaginationItem-page:hover': {
+              backgroundColor:
+                theme.mode === 'light'
+                  ? theme.color.gray_10
+                  : theme.color.transparent_10,
+            },
+            '&:hover': {
+              '&:not(.MuiPaginationItem-ellipsis, .Mui-selected)': {
+                // (...)은 호버 제외
+                backgroundColor: theme.color.transparent_10, // 색상은 예시
+              },
+            },
           },
         }}
         {...props}

--- a/src/components/Common/Pagination/Pagination.tsx
+++ b/src/components/Common/Pagination/Pagination.tsx
@@ -9,6 +9,7 @@ interface CustomPaginationProps extends PaginationProps {
   arrowSize?: string;
   selectedBgColor?: string;
   selectedTextColor?: string;
+  siblingCount?: number;
 }
 
 /**
@@ -28,6 +29,7 @@ export default function Pagination({
   arrowSize,
   selectedBgColor,
   selectedTextColor,
+  siblingCount,
   ...props
 }: CustomPaginationProps) {
   const { theme } = useCustomTheme();
@@ -36,7 +38,7 @@ export default function Pagination({
       <MuiPagination
         // 설정 기본값
         defaultPage={1} // 페이지 기본 위치
-        siblingCount={1} // 현재 페이지 기준 양쪽 표시할 페이지 수
+        siblingCount={siblingCount || 1} // 현재 페이지 기준 양쪽 표시할 페이지 수
         boundaryCount={0} // 시작 끝에 표시할 페이지 수
         showFirstButton // 시작페이지 이동 버튼 표시 여부
         showLastButton // 끝페이지 이동 버튼 표시 여부

--- a/src/components/Common/Pagination/Pagination.tsx
+++ b/src/components/Common/Pagination/Pagination.tsx
@@ -42,7 +42,6 @@ export default function Pagination({
         showLastButton // 끝페이지 이동 버튼 표시 여부
         size={size} // Pagination 컴포넌트 전체 사이즈
         sx={{
-          //
           '& .MuiPaginationItem-root': {
             color: textColor || theme.color.text_primary_color,
             fontSize: textSize || theme.size.M,

--- a/src/components/Common/Pagination/Pagination.tsx
+++ b/src/components/Common/Pagination/Pagination.tsx
@@ -1,0 +1,63 @@
+import { Pagination as MuiPagination, PaginationProps } from '@mui/material';
+
+import { useCustomTheme } from '@/hooks/useCustomTheme';
+
+interface CustomPaginationProps extends PaginationProps {
+  size?: 'small' | 'medium' | 'large';
+  textColor?: string;
+  textSize?: string;
+  arrowSize?: string;
+  selectedBgColor?: string;
+  selectedTextColor?: string;
+}
+
+/**
+ * MUI Pagination 컴포넌트를 커스텀 사용하기 편하도록 만든 공통 컴포넌트
+ * @param {'small' | 'medium' | 'large'} size Pagination 컴포넌트 전체 사이즈, 기본값 `'large'`
+ * @param {string} textColor 페이지 번호 텍스트 색깔, 기본값 `theme.color.text_primary_color`
+ * @param {string} textSize 페이지 번호 텍스트 크기, 기본값 `theme.size.M`
+ * @param {string} arrowSize 화살표 아이콘 크기, 기본값 `theme.size.L`
+ * @param {string} selectedBgColor 선택된 페이지 아이콘 배경 색, 기본값 `theme.color.secondary_color`
+ * @param {string} selectedTextColor 선택된 페이지 번호 색, 기본값 `theme.color.background_primary`
+ * @returns
+ */
+export default function Pagination({
+  size = 'large',
+  textColor,
+  textSize,
+  arrowSize,
+  selectedBgColor,
+  selectedTextColor,
+  ...props
+}: CustomPaginationProps) {
+  const { theme } = useCustomTheme();
+  return (
+    <>
+      <MuiPagination
+        // 설정 기본값
+        defaultPage={1} // 페이지 기본 위치
+        siblingCount={1} // 현재 페이지 기준 양쪽 표시할 페이지 수
+        boundaryCount={0} // 시작 끝에 표시할 페이지 수
+        showFirstButton // 시작페이지 이동 버튼 표시 여부
+        showLastButton // 끝페이지 이동 버튼 표시 여부
+        size={size} // Pagination 컴포넌트 전체 사이즈
+        sx={{
+          //
+          '& .MuiPaginationItem-root': {
+            color: textColor || theme.color.text_primary_color,
+            fontSize: textSize || theme.size.M,
+
+            '& .MuiSvgIcon-root': {
+              fontSize: arrowSize || theme.size.L,
+            },
+            '&.Mui-selected': {
+              backgroundColor: selectedBgColor || theme.color.secondary_color,
+              color: selectedTextColor || theme.color.background_primary,
+            },
+          },
+        }}
+        {...props}
+      />
+    </>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export { default as Input } from './Common/Input/Input';
 export { default as Menu } from './Common/Menu/Menu';
 export { default as Message } from './Common/Message/Message';
 export { default as Modal } from './Common/Modal/Modal';
+export { default as Pagination } from './Common/Pagination/Pagination';
 export { default as Spinner } from './Common/Spinner/Spinner';
 export { default as Tag } from './Common/Tag/Tag';
 export { default as ThemeModeToggleButton } from './Common/ThemeModeToggleButton/ThemeModeToggleButton';


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->
Pagination 공통 컴포넌트를 구현했습니다.

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가

## 💻 작업 내용
#### 컴포넌트 동작 화면
![페이지네이션](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/025cadda-900c-4eda-abca-6216eb32567c)


#### 테스트 코드
<details>
<summary>ProfilePage.tsx</summary>

```tsx
import { ChangeEvent, useState } from 'react';

import { Pagination } from '@/components';

export default function ProfilePage() {
  const [page, setPage] = useState(1);

  const handleChangePage = (event: ChangeEvent<unknown>, pageNum: number) => {
    if (event) setPageNum(pageNum);
  };

  return (
    <div>
      현재 페이지 : {page}
      <Pagination
        count={10} // 총 10페이지
        defaultPage={1} // 기본 페이지 번호: 1
        page={page} // 현재 페이지
        onChange={handleChangePage}
      />
    </div>
  );
}

```

</details>

<!-- PR 본문을 입력하세요. -->

- Pagination 공통 컴포넌트를 구현했습니다.
- 설정 및 확인해야하는 기본적인 props 옵션은 다음과 같습니다.
  - `count` : 총 페이지 수
  - `page` : 현재 페이지 (사용하는 컴포넌트 안에서 상태 관리)
  - `onChange` : 페이지 변경 이벤트 props 함수 ( `page`의 set 함수와 연결하면 됩니다.)
  - `size` : Pagination의 전체적인 크기 ('small' | 'medium' | 'large'), 리터럴 타입입니다.
  - `textColor`, `textSize` : 페이지 넘버의 텍스트 크기 및 색깔
  - `arrowSize` : 화살표 아이콘 크기
  - `selectedBgColor`, `selectedTextColor` : 선택된 페이지 넘버 배경, 글자 색
  - 그 외 MUI Pagination 자체 props 옵션은 아래 링크에서 확인하시고 추가하시면 우선 적용됩니다.
  https://mui.com/material-ui/api/pagination/

## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
- 혹시나 디자인이나 동작이 이상하면 알려주세요!
