### PR TITLE
[✨feat]: 로그인 실패 alert 및 로그인, 회원가입 페이지 디자인 변경

### DIFF
--- a/src/components/Common/Header/Header.tsx
+++ b/src/components/Common/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Avatar, ThemeModeToggleButton } from '@/components';
 import { useMyInfo } from '@/hooks/Api/useMembers';
@@ -8,11 +8,12 @@ import * as S from './Header.style';
 
 export default function Header() {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
 
   // Todo: 수영님의 MeStore에서 추출하는 것으로 이후 변경
   const { data: myInfo, refetch } = useMyInfo();
 
-  if (!myInfo) {
+  if (!myInfo && pathname !== '/signup') {
     refetch();
   }
 
@@ -34,12 +35,14 @@ export default function Header() {
       </S.LogoWrapper>
       <S.IconWrapper>
         <ThemeModeToggleButton />
-        <S.AvatarWrapper>
-          <Avatar
-            src={myProfileImage}
-            onClick={handleMyProfileClick}
-          />
-        </S.AvatarWrapper>
+        {pathname !== '/signup' ? (
+          <S.AvatarWrapper>
+            <Avatar
+              src={myProfileImage}
+              onClick={handleMyProfileClick}
+            />
+          </S.AvatarWrapper>
+        ) : null}
       </S.IconWrapper>
     </S.HeaderWrapper>
   );

--- a/src/components/LoginForm/LoginForm.style.ts
+++ b/src/components/LoginForm/LoginForm.style.ts
@@ -23,6 +23,7 @@ export const LoginFormContainer = styled.form`
     display: flex;
     flex-direction: column;
     gap: ${theme.size.M};
+    user-select: none;
   `}
 `;
 
@@ -37,6 +38,7 @@ export const LoginInputContainer = styled.ul`
 export const LoginInputItem = styled.li`
   ${({ theme }) => css`
     label {
+      font-size: ${theme.size.M};
       font-weight: ${theme.fontWeight.semiBold};
       color: ${theme.color.text_primary_color};
     }
@@ -62,6 +64,7 @@ export const LoginOptionContainer = styled(Row)`
   ${({ theme }) => css`
     align-items: center;
     justify-content: space-between;
+    user-select: none;
     & {
       span {
         width: 1.2rem;

--- a/src/components/LoginForm/LoginForm.style.ts
+++ b/src/components/LoginForm/LoginForm.style.ts
@@ -1,7 +1,7 @@
 import { NavLink } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
-import { Row } from '@/styles/GlobalStyle';
+import { ButtonHoverTransition, Row } from '@/styles/GlobalStyle';
 import { ThemeType } from '@/styles/theme';
 
 import { Button } from '..';
@@ -55,6 +55,7 @@ export const LoginInputItem = styled.li`
 
 export const LoginButton = styled(Button)`
   width: 100%;
+  ${ButtonHoverTransition}
 `;
 
 export const LoginOptionContainer = styled(Row)`

--- a/src/components/LoginForm/LoginForm.style.ts
+++ b/src/components/LoginForm/LoginForm.style.ts
@@ -41,6 +41,7 @@ export const LoginInputItem = styled.li`
       color: ${theme.color.text_primary_color};
     }
     input {
+      padding-left: ${theme.size.L};
       color: ${theme.color.text_primary_color};
       &::placeholder {
         color: ${theme.mode === 'light'

--- a/src/pages/ProfilePage/PasswordEditModal/PasswordEditModal.style.ts
+++ b/src/pages/ProfilePage/PasswordEditModal/PasswordEditModal.style.ts
@@ -1,5 +1,7 @@
 import styled, { css } from 'styled-components';
 
+import { ButtonHoverTransition } from '@/styles/GlobalStyle';
+
 export const ModalTitle = styled.p`
   ${({ theme }) => css`
     position: absolute;
@@ -19,6 +21,7 @@ export const ModalForm = styled.form`
     width: 30rem;
     > :last-child {
       width: 50%;
+      ${ButtonHoverTransition}
     }
   `}
 `;

--- a/src/pages/ProfilePage/ProfileEditModal/ProfileEditModal.style.ts
+++ b/src/pages/ProfilePage/ProfileEditModal/ProfileEditModal.style.ts
@@ -1,5 +1,7 @@
 import styled, { css } from 'styled-components';
 
+import { ButtonHoverTransition } from '@/styles/GlobalStyle';
+
 export const ModalTitle = styled.p`
   ${({ theme }) => css`
     position: absolute;
@@ -18,6 +20,7 @@ export const ModalForm = styled.form`
   width: 30rem;
   button {
     width: 50%;
+    ${ButtonHoverTransition}
   }
 `;
 

--- a/src/pages/ProfilePage/ProfilePage.style.ts
+++ b/src/pages/ProfilePage/ProfilePage.style.ts
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { Col, Row } from '@/styles/GlobalStyle';
+import { ButtonHoverTransition, Col, Row } from '@/styles/GlobalStyle';
 
 import PasswordEditModal from './PasswordEditModal/PasswordEditModal';
 import ProfileEditModal from './ProfileEditModal/ProfileEditModal';
@@ -76,6 +76,7 @@ export const UserInfoButtonContainer = styled(Row)`
       height: 3rem;
       font-size: ${theme.size.M};
       border: 1px solid ${theme.color.gray_20};
+      ${ButtonHoverTransition}
     }
   `}
 `;

--- a/src/pages/SignUpPage/SignUpPage.style.ts
+++ b/src/pages/SignUpPage/SignUpPage.style.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { css } from 'styled-components';
 
 import { Button } from '@/components';
+import { ButtonHoverTransition } from '@/styles/GlobalStyle';
 
 // 반복되는 너비 설정을 mixin으로 분리한다.
 const commonWidth = css`
@@ -76,18 +77,13 @@ export const SignUpInputItem = styled.li`
 
 export const SignUpButton = styled(Button)`
   ${commonWidth}
-  transition: transform 0.2s ease;
-  &:not(:disabled):hover {
-    transform: scale(1.05);
-  }
+  ${ButtonHoverTransition}
 `;
+
 export const HomeButton = styled(Button)`
   ${({ theme }) => css`
     ${commonWidth}
+    ${ButtonHoverTransition}
     margin-top: ${theme.size.S};
-    transition: transform 0.2s ease;
-    &:hover {
-      transform: scale(1.05);
-    }
   `}
 `;

--- a/src/pages/SignUpPage/SignUpPage.style.ts
+++ b/src/pages/SignUpPage/SignUpPage.style.ts
@@ -58,7 +58,7 @@ export const SignUpInputItem = styled.li`
     }
 
     input {
-      padding-left: 2rem;
+      padding-left: ${theme.size.L};
       color: ${theme.color.text_primary_color};
       &::placeholder {
         line-height: 4rem;
@@ -68,7 +68,7 @@ export const SignUpInputItem = styled.li`
 
     > div {
       > :nth-child(3) {
-        height: 1.5rem;
+        height: ${theme.size.M};
       }
     }
   `}

--- a/src/pages/SignUpPage/SignUpPage.style.ts
+++ b/src/pages/SignUpPage/SignUpPage.style.ts
@@ -24,6 +24,7 @@ export const SignUpFormContainer = styled.form`
     justify-content: center;
     width: 100%;
     height: 100%;
+    user-select: none;
 
     > :nth-child(2) {
       ${commonWidth}
@@ -56,6 +57,7 @@ export const SignUpInputItem = styled.li`
       font-size: ${theme.size.M};
       font-weight: ${theme.fontWeight.bold};
       color: ${theme.color.text_primary_color};
+      user-select: none;
     }
 
     input {

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -120,7 +120,7 @@ export default function SignUpPage() {
         >
           가입하기
         </S.SignUpButton>
-        <S.HomeButton onClick={handleClickHome}>홈으로</S.HomeButton>
+        <S.HomeButton onClick={handleClickHome}>시작페이지로</S.HomeButton>
       </S.SignUpFormContainer>
     </S.SignUpPageWrapper>
   );

--- a/src/services/handleAxiosError.ts
+++ b/src/services/handleAxiosError.ts
@@ -13,11 +13,11 @@ const handleAxiosError = (errorAxios: AxiosError<ErrorDataType>) => {
     switch (errorCode) {
       // 에러코드 별로 추가할 수 있다.
       // Todo: 객체 형태로 키 밸류 형태로 리팩토링한다.
-      case 'E00202':
-        console.log('비밀번호가 일치하지 않습니다.');
+      case 'E00202': // 비밀번호가 일치하지 않습니다.
+        alert('로그인 정보가 올바르지 않습니다. 다시 로그인해주세요.');
         break;
-      case 'E01302':
-        console.log('가입되지 않은 이메일입니다.');
+      case 'E01302': // 가입되지 않은 이메일입니다.
+        alert('가입되지 않은 이메일입니다. 다시 로그인해주세요.');
         break;
       case 'E00201': // 401 에러와 같이 인증 관련 접근 제한 에러
         localStorage.removeItem(LOCAL_ACCESSTOKEN);

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -1,4 +1,5 @@
 import styled, { createGlobalStyle } from 'styled-components';
+import { css } from 'styled-components';
 
 export const GlobalStyle = createGlobalStyle`
   * {
@@ -73,4 +74,11 @@ export const Col = styled.div`
 export const Row = styled.div`
   display: flex;
   flex-direction: row;
+`;
+// 버튼 hover 시 트랜지션 효과를 일관성있게 적용하기 위해 분리했다.
+export const ButtonHoverTransition = css`
+  transition: transform 0.2s ease;
+  &:not(:disabled):hover {
+    transform: scale(1.03);
+  }
 `;


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->
로그인 실패 시 alert 기능을 추가 및 인증 관련 페이지 디자인을 변경했습니다.

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 💻 작업 내용

<!-- PR 본문을 입력하세요. -->
### 핵심 구현 및 변경사항
- 로그인 실패시 alert 창 표시 (https://github.com/1e5i-Shark/algobaro-fe/commit/b550a490ef44f5eec65b11c05e919cb55ef5ef3f)
  - 로그인 인증 정보가 틀렸을 경우
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/e44b6855-ddc1-47f0-b966-e66945208682)
  - 가입되지 않은 이메일의 경우
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/29d9ce2f-e09f-4d5a-b168-deff690c2cdc)

### Global CSS 추가사항
- 버튼에 hover 했을 경우 scale이 커지는 트랜지션 효과를 글로벌 스타일로 적용해서 재사용성을 높였습니다. (https://github.com/1e5i-Shark/algobaro-fe/commit/b6c7210c0b13a7533a449d2cedaff3fbc65492a7)
  - 로그인, 회원가입, 프로필 페이지, 각종 모달에 자주 사용되는 것 같아 styled component css 메서드를 활용해서 mixin 처럼 추가할 수 있도록 했습니다.

### 디자인 추가 변경사항
- 로그인, 회원가입 form 내부 라벨과 텍스트에 `user-select: none` 속성을 적용했습니다.
- 회원가입페이지에서 '홈으로' 텍스르르 '시작페이지로' 로 변경했습니다. 
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/bdda16cb-4e72-41c6-8658-38c0ad360b23)
- Header에서 회원가입 페이지일 때는 프로필 아바타가 표시되지 않게 했습니다. (https://github.com/1e5i-Shark/algobaro-fe/commit/bafdcfd314f6e3ca81cc5bd46bacf27783a069bf)
  - 추가적으로 myInfo 데이터를 refetch하지 않도록 조건을 추가했습니다.




## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
- 로그인 실패에 대한 에러 alert가 잘 나타나는지 서버와의 통신에서 어떤 에러인지 확인이 가능한지 (보안적 이슈) 테스트 부탁드립니다.
- 버튼 트랜지션 효과나 변경한 디자인이 잘 동작하는지 여부를 확인해주시고 수정할 부분이 있는지 체크부탁드립니다.