### PR TITLE
[✨feat]: 코드 공유 페이지 레이아웃 구현

### DIFF
--- a/src/components/Common/Header/PSHeader.tsx
+++ b/src/components/Common/Header/PSHeader.tsx
@@ -1,5 +1,6 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
+import { MOCK_ROOM_DATA } from '@/constants/room';
 import { useCustomTheme } from '@/hooks/useCustomTheme';
 import useModal from '@/hooks/useModal';
 import ProblemTimer from '@/pages/ProblemSolvePage/ProblemTimer/ProblemTimer';
@@ -13,6 +14,10 @@ import * as S from './PSHeader.style';
 export default function PSHeader() {
   const { theme } = useCustomTheme();
   const { modalRef, isOpen, openModal, closeModal } = useModal();
+  const location = useLocation();
+
+  const isProblemSolvePage =
+    location.pathname.split('/')[1] === PATH.PROBLEMSOLVE.replace('/', '');
 
   const navigate = useNavigate();
 
@@ -24,19 +29,28 @@ export default function PSHeader() {
     openModal();
   };
 
+  const handleNavigateToRoom = () => {
+    navigate(`${PATH.ROOM}/${MOCK_ROOM_DATA.id}`, {
+      state: MOCK_ROOM_DATA.roomShortUuid,
+    });
+  };
+
   return (
     <S.HeaderWrapper>
       <S.TimerWrapper>
-        <ProblemTimer seconds={5} />
+        <ProblemTimer
+          seconds={5}
+          isProblemSolvePage={isProblemSolvePage}
+        />
       </S.TimerWrapper>
       <S.ButtonWrapper>
         <ThemeModeToggleButton />
         <Button
           height="4rem"
           backgroundColor={theme.color.red}
-          onClick={handleGiveUp}
+          onClick={isProblemSolvePage ? handleGiveUp : handleNavigateToRoom}
         >
-          포기하기
+          {isProblemSolvePage ? '포기하기' : '리뷰 종료'}
         </Button>
       </S.ButtonWrapper>
       <Modal

--- a/src/components/Common/Timer/Timer.tsx
+++ b/src/components/Common/Timer/Timer.tsx
@@ -85,7 +85,7 @@ export default function Timer({
         clearInterval(timer.current);
       }
     };
-  }, []);
+  }, [isStop]);
 
   return <S.Wrapper>{convertedTime(timeLeft, padLength)}</S.Wrapper>;
 }

--- a/src/constants/room.ts
+++ b/src/constants/room.ts
@@ -14,3 +14,8 @@ export const ROOM_LIMIT_DATASET = [1, 2, 3, 4, 5, 6].reduce(
   },
   {} as Record<number, string>
 );
+
+export const MOCK_ROOM_DATA = {
+  id: 1,
+  roomShortUuid: '2ad2e9db',
+};

--- a/src/pages/ProblemSharePage/ProblemSharePage.style.ts
+++ b/src/pages/ProblemSharePage/ProblemSharePage.style.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 4rem 2rem;
+`;
+
+const CodeEditorWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  margin-top: 2rem;
+`;
+
+export { CodeEditorWrapper, Wrapper };

--- a/src/pages/ProblemSharePage/ProblemSharePage.tsx
+++ b/src/pages/ProblemSharePage/ProblemSharePage.tsx
@@ -1,3 +1,34 @@
+import { useState } from 'react';
+
+import { CodeEditor } from '@/components';
+import { MOCK_ROOM_DATA } from '@/constants/room';
+
+import { MOCK_USER_DATA } from './constants';
+import * as S from './ProblemSharePage.style';
+import UserProfileList from './UserProfileList/UserProfileList';
+
+const userData = MOCK_USER_DATA;
+const myId = 'soopy368@test.com';
+const myInfo = MOCK_USER_DATA.find(user => user.id === myId);
+
 export default function ProblemSharePage() {
-  return <div>ProblemSharePage</div>;
+  const [selectedUser, setSelectedUser] = useState(myInfo);
+
+  const handleUserClick = (userId: string) => {
+    const filteredUser = userData.find(user => user.id === userId);
+    setSelectedUser(filteredUser ?? myInfo);
+  };
+
+  return (
+    <S.Wrapper>
+      <UserProfileList
+        selectedUser={selectedUser}
+        userList={MOCK_USER_DATA}
+        onUserClick={handleUserClick}
+      />
+      <S.CodeEditorWrapper>
+        <CodeEditor roomUuid={MOCK_ROOM_DATA.roomShortUuid} />
+      </S.CodeEditorWrapper>
+    </S.Wrapper>
+  );
 }

--- a/src/pages/ProblemSharePage/UserProfileList/UserProfileList.style.ts
+++ b/src/pages/ProblemSharePage/UserProfileList/UserProfileList.style.ts
@@ -1,0 +1,29 @@
+import styled, { css } from 'styled-components';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const UserList = styled.ul`
+  display: flex;
+  gap: 2rem;
+`;
+
+const UserItem = styled.li`
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-items: center;
+  width: 8rem;
+  cursor: pointer;
+`;
+
+const UserName = styled.div<{ $isSelected: boolean }>`
+  ${({ theme, $isSelected }) => css`
+    color: ${$isSelected ? theme.color.red : theme.color.text_primary_color};
+    text-align: center;
+  `};
+`;
+
+export { UserItem, UserList, UserName, Wrapper };

--- a/src/pages/ProblemSharePage/UserProfileList/UserProfileList.tsx
+++ b/src/pages/ProblemSharePage/UserProfileList/UserProfileList.tsx
@@ -1,0 +1,42 @@
+import { Avatar, EllipsisText } from '@/components';
+
+import { User } from '../type';
+import * as S from './UserProfileList.style';
+
+interface UserProfileListProps {
+  selectedUser: User;
+  userList: User[];
+  onUserClick: (userId: string) => void;
+}
+
+export default function UserProfileList({
+  selectedUser,
+  userList,
+  onUserClick,
+}: UserProfileListProps) {
+  return (
+    <S.Wrapper>
+      <S.UserList>
+        {userList.map(user => (
+          <S.UserItem
+            key={user.id}
+            onClick={() => onUserClick(user.id)}
+          >
+            <Avatar
+              size="L"
+              src={user.profileImage ?? ''}
+            />
+            <S.UserName $isSelected={selectedUser.id === user.id}>
+              <EllipsisText
+                width="8rem"
+                lineClamp={2}
+              >
+                {user.nickname}
+              </EllipsisText>
+            </S.UserName>
+          </S.UserItem>
+        ))}
+      </S.UserList>
+    </S.Wrapper>
+  );
+}

--- a/src/pages/ProblemSharePage/UserProfileList/UserProfileList.tsx
+++ b/src/pages/ProblemSharePage/UserProfileList/UserProfileList.tsx
@@ -4,7 +4,7 @@ import { User } from '../type';
 import * as S from './UserProfileList.style';
 
 interface UserProfileListProps {
-  selectedUser: User;
+  selectedUser?: User;
   userList: User[];
   onUserClick: (userId: string) => void;
 }
@@ -26,7 +26,7 @@ export default function UserProfileList({
               size="L"
               src={user.profileImage ?? ''}
             />
-            <S.UserName $isSelected={selectedUser.id === user.id}>
+            <S.UserName $isSelected={selectedUser?.id === user.id}>
               <EllipsisText
                 width="8rem"
                 lineClamp={2}

--- a/src/pages/ProblemSharePage/constants.ts
+++ b/src/pages/ProblemSharePage/constants.ts
@@ -1,0 +1,27 @@
+export const MOCK_USER_DATA = [
+  {
+    id: 'soopy368@test.com',
+    nickname: '수박이박수',
+    role: 'HOST',
+    joinTime: '2024-03-04T00:45:18',
+    ready: true,
+    profileImage:
+      'https://algobaro-bucket.s3.ap-northeast-2.amazonaws.com/4e7af082-8-%E1%84%84%E1%85%A1%E1%84%87%E1%85%A9%E1%86%BC%E1%84%80%E1%85%A9%E1%84%8B%E1%85%A3%E1%86%BC%E1%84%8B%E1%85%B52.jpeg',
+  },
+  {
+    id: 'test1@test.com',
+    nickname: '닉네임이엄청나게긴유저',
+    profileImage: null,
+    role: 'PARTICIPANT',
+    joinTime: '2024-03-04T00:45:18',
+    ready: true,
+  },
+  {
+    id: 'test2@test.com',
+    nickname: '코딩의신',
+    profileImage: null,
+    role: 'PARTICIPANT',
+    joinTime: '2024-03-04T00:45:36',
+    ready: false,
+  },
+];

--- a/src/pages/ProblemSharePage/constants.ts
+++ b/src/pages/ProblemSharePage/constants.ts
@@ -1,4 +1,6 @@
-export const MOCK_USER_DATA = [
+import { User } from './type';
+
+export const MOCK_USER_DATA: User[] = [
   {
     id: 'soopy368@test.com',
     nickname: '수박이박수',

--- a/src/pages/ProblemSharePage/type.ts
+++ b/src/pages/ProblemSharePage/type.ts
@@ -1,0 +1,7 @@
+export interface User {
+  id: string;
+  profileImage: string | null;
+  nickname: string;
+  joinTime: string;
+  ready: boolean;
+}

--- a/src/pages/ProblemSharePage/type.ts
+++ b/src/pages/ProblemSharePage/type.ts
@@ -4,4 +4,5 @@ export interface User {
   nickname: string;
   joinTime: string;
   ready: boolean;
+  role: string;
 }

--- a/src/pages/ProblemSolvePage/ProblemEndModal/ProblemEndModal.tsx
+++ b/src/pages/ProblemSolvePage/ProblemEndModal/ProblemEndModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Modal, Timer } from '@/components';
+import { MOCK_ROOM_DATA } from '@/constants/room';
 import { PATH } from '@/routes/path';
 
 import * as S from './ProblemEndModal.style';
@@ -23,7 +24,8 @@ export default function ProblemEndModal({
 
   useEffect(() => {
     if (isEnd) {
-      navigate(PATH.PROBLEMSHARE);
+      navigate(`${PATH.PROBLEMSHARE}/${MOCK_ROOM_DATA.id}`);
+      closeModal();
     }
   }, [isEnd]);
 

--- a/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
@@ -3,6 +3,7 @@ import { Panel, PanelGroup } from 'react-resizable-panels';
 import { Button, CodeEditor, ResizeHandle } from '@/components';
 import { useCustomTheme } from '@/hooks/useCustomTheme';
 import { useCompile, useSubmission } from '@/hooks/useProblemSolve';
+import useTimerStore from '@/store/TimerStore';
 
 import { DIRECTION, MOCK_DATA, SIZE_PERCENTAGE } from './constants';
 import ProblemExecution from './ProblemExecution/ProblemExecution';
@@ -15,11 +16,15 @@ export default function ProblemSolvePage() {
   const { mutate: compileMutate } = useCompile();
   const { mutate: submitMutate } = useSubmission();
 
+  const setIsStop = useTimerStore(state => state.setIsStop);
+
   const handleCompileExecution = () => {
     compileMutate(MOCK_DATA.COMPILE);
   };
+
   const handleSubmit = () => {
-    submitMutate(MOCK_DATA.SUBMISSION);
+    // submitMutate(MOCK_DATA.SUBMISSION);
+    setIsStop(false);
   };
 
   return (

--- a/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
@@ -23,7 +23,7 @@ export default function ProblemSolvePage() {
   };
 
   const handleSubmit = () => {
-    // submitMutate(MOCK_DATA.SUBMISSION);
+    submitMutate(MOCK_DATA.SUBMISSION);
     setIsStop(false);
   };
 

--- a/src/pages/ProblemSolvePage/ProblemTimer/ProblemTimer.style.ts
+++ b/src/pages/ProblemSolvePage/ProblemTimer/ProblemTimer.style.ts
@@ -3,6 +3,10 @@ import styled, { css } from 'styled-components';
 import { Row } from '@/styles/GlobalStyle';
 
 const Wrapper = styled(Row)`
+  align-items: center;
+`;
+
+const TimeLeftWrapper = styled.div`
   ${({ theme }) => css`
     width: fit-content;
     padding: 1rem 2.5rem;
@@ -11,8 +15,6 @@ const Wrapper = styled(Row)`
     border-radius: ${theme.shape.round};
   `}
 `;
-
-const TimeLeftWrapper = styled.div``;
 
 const TimeLeftText = styled.span`
   margin-right: 0.6rem;
@@ -25,4 +27,18 @@ const TimeOverText = styled.span`
   `}
 `;
 
-export { TimeLeftText, TimeLeftWrapper, TimeOverText, Wrapper };
+const TimeStartButton = styled.button`
+  ${({ theme }) => css`
+    padding: 0 1rem;
+    font-size: ${theme.size.M};
+    color: ${theme.color.red};
+  `}
+`;
+
+export {
+  TimeLeftText,
+  TimeLeftWrapper,
+  TimeOverText,
+  TimeStartButton,
+  Wrapper,
+};

--- a/src/pages/ProblemSolvePage/ProblemTimer/ProblemTimer.tsx
+++ b/src/pages/ProblemSolvePage/ProblemTimer/ProblemTimer.tsx
@@ -2,34 +2,45 @@ import { useState } from 'react';
 
 import { Timer } from '@/components';
 import useModal from '@/hooks/useModal';
+import useTimerStore from '@/store/TimerStore';
 
 import ProblemEndModal from '../ProblemEndModal/ProblemEndModal';
 import * as S from './ProblemTimer.style';
 interface TimerProps {
   minutes?: number;
   seconds?: number;
+  isProblemSolvePage: boolean;
   openModal?: () => void;
 }
 
-export default function ProblemTimer({ minutes, seconds }: TimerProps) {
+export default function ProblemTimer({
+  minutes,
+  seconds,
+  isProblemSolvePage,
+}: TimerProps) {
   const [isEnd, setIsEnd] = useState(false);
   const { modalRef, isOpen, openModal, closeModal } = useModal();
+
+  // navigate 테스트용 코드 (삭제 예정)
+  const isStop = useTimerStore(state => state.isStop);
 
   return (
     <S.Wrapper>
       <S.TimeLeftWrapper>
-        {isEnd ? (
+        {isEnd || !isProblemSolvePage ? (
           <S.TimeOverText>시험 종료</S.TimeOverText>
         ) : (
           <S.TimeLeftText>남은 시간</S.TimeLeftText>
         )}
-        <Timer
-          isStop
-          minutes={minutes}
-          seconds={seconds}
-          openModal={openModal}
-          setIsEnd={setIsEnd}
-        />
+        {isProblemSolvePage && (
+          <Timer
+            isStop={isStop}
+            minutes={minutes}
+            seconds={seconds}
+            openModal={openModal}
+            setIsEnd={setIsEnd}
+          />
+        )}
       </S.TimeLeftWrapper>
       <ProblemEndModal
         modalRef={modalRef}

--- a/src/store/TimerStore/index.ts
+++ b/src/store/TimerStore/index.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+interface TimerStateProps {
+  isStop: boolean;
+  setIsStop: (isStop: boolean) => void;
+}
+
+const useTimerStore = create<TimerStateProps>()(
+  devtools(set => ({
+    isStop: true,
+    setIsStop: (isStop: boolean) => set({ isStop }),
+  }))
+);
+
+export default useTimerStore;


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->

사용자별로 제출한 코드를 볼 수 있는 화면을 구성합니다.
코드 에디터의 공동 편집 기능을 사용합니다.


## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 💻 작업 내용

<!-- PR 본문을 입력하세요. -->

- 코드 풀이 페이지 / 코드 공유 페이지별 PSHeader 분기 처리를 해주었습니다.
- 유저 프로필 리스트 컴포넌트 추가
- 공동 편집 코드 에디터 추가

## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->

- 코드 공유 페이지 URL: **`/problemshare/1`**
- Mock 데이터를 이용하여 1번 방을 기준으로 navigate 테스트가 가능하게 구현하였습니다.
  - roomId: 1, roomShortUuid: 2ad2e9db 
- **`코드 풀이 페이지 (/problemsolve/1)`** 에서 실행 버튼을 클릭하면 타이머가 실행되고, 코드 공유 페이지로 이동합니다.
- 레이아웃 작업 위주라서 간단하게 리뷰 후 머지해도 될 것 같습니다!