### PR TITLE
[✨feat]: 문제 풀이 페이지에서 크롤링한 문제 정보 표시

### DIFF
--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -3,6 +3,9 @@ export const QUERY_KEY = {
   ROOM: {
     UUID_INFO: 'roomUuidInfo',
   },
+  PROBLEM: {
+    PROBLEM_INFO: 'problemInfo',
+  },
 };
 export const SOLVED_HISTORIES = 'solvedHistoryList';
 export const ROOMS_KEY = 'roomsList';

--- a/src/hooks/Api/useProblem.ts
+++ b/src/hooks/Api/useProblem.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { QUERY_KEY } from '@/constants/queryKey';
+import getProblemInfo from '@/services/Problem/getProblemInfo';
+
+export const useProblemInfo = (problemLink: string) => {
+  return useQuery({
+    queryKey: [QUERY_KEY.PROBLEM.PROBLEM_INFO, problemLink],
+    queryFn: () => getProblemInfo(problemLink),
+    enabled: false,
+  });
+};

--- a/src/pages/ProblemSolvePage/ProblemSection/ProblemSection.style.ts
+++ b/src/pages/ProblemSolvePage/ProblemSection/ProblemSection.style.ts
@@ -6,6 +6,7 @@ const ProblemWrapper = styled(Col)`
   ${({ theme }) => css`
     height: 100%;
     padding: 2rem;
+    overflow-y: scroll;
     background-color: ${theme.color.background_editor};
   `}
 `;
@@ -15,6 +16,17 @@ const ProblemTextWrapper = styled.li`
   flex-direction: column;
   word-break: keep-all;
   white-space: pre-line;
+`;
+
+const ProblemContent = styled.div`
+  padding: 1rem 0 2rem;
+  line-height: 2.5rem;
+  ul {
+    line-height: 1.5rem;
+  }
+  li {
+    list-style: inside;
+  }
 `;
 
 const ProblemTitle = styled.span`
@@ -43,6 +55,7 @@ const ProblemCode = styled.pre`
 
 export {
   ProblemCode,
+  ProblemContent,
   ProblemText,
   ProblemTextWrapper,
   ProblemTitle,

--- a/src/pages/ProblemSolvePage/ProblemSection/ProblemSection.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSection/ProblemSection.tsx
@@ -1,26 +1,46 @@
+import { useEffect } from 'react';
+
+import { useProblemInfo } from '@/hooks/Api/useProblem';
+import useRoomStore from '@/store/RoomStore';
+
+import parseProblemInfo from './parseProblemInfo';
 import * as S from './ProblemSection.style';
 
-const problemTextList = [
-  {
-    title: '문제',
-    text: '두 정수 A와 B를 입력받은 다음, A+B를 출력하는 프로그램을 작성하시오.',
-  },
-  { title: '입력', text: '첫째 줄에 A와 B가 주어진다. (0 < A, B < 10)' },
-  { title: '출력', text: '첫째 줄에 A+B를 출력한다.' },
-  { title: '예제 입력 1 ', code: '1 2' },
-  { title: '예제 출력 1 ', code: '3' },
-];
-
 export default function ProblemSection() {
+  const { roomData } = useRoomStore();
+
+  const { data, refetch } = useProblemInfo(roomData.problemLink);
+
+  useEffect(() => {
+    refetch();
+  }, []);
+
+  const problemInfoHtml = data?.response.problemInfoHtml;
+  // 문제 크롤링 정보 html 문자열 값을 파싱 후 객체 배열 형태로 변환한다.
+  const problemInfo = parseProblemInfo(problemInfoHtml);
+
   return (
     <S.ProblemWrapper>
-      {problemTextList.map((problem, index) => (
-        <S.ProblemTextWrapper key={index}>
-          <S.ProblemTitle>{problem.title}</S.ProblemTitle>
-          {problem.text && <S.ProblemText>{problem.text}</S.ProblemText>}
-          {problem.code && <S.ProblemCode>{problem.code}</S.ProblemCode>}
-        </S.ProblemTextWrapper>
-      ))}
+      {problemInfo &&
+        problemInfo.map((problem, index) => (
+          <S.ProblemTextWrapper key={index}>
+            {problem.text || problem.code || problem.domString ? (
+              <>
+                {problem.title && (
+                  <S.ProblemTitle>{problem.title}</S.ProblemTitle>
+                )}
+                {problem.domString && (
+                  <S.ProblemContent
+                    dangerouslySetInnerHTML={{ __html: problem.domString }}
+                  ></S.ProblemContent>
+                )}
+                {problem.text && <S.ProblemText>{problem.text}</S.ProblemText>}
+
+                {problem.code && <S.ProblemCode>{problem.code}</S.ProblemCode>}
+              </>
+            ) : null}
+          </S.ProblemTextWrapper>
+        ))}
     </S.ProblemWrapper>
   );
 }

--- a/src/pages/ProblemSolvePage/ProblemSection/parseProblemInfo.ts
+++ b/src/pages/ProblemSolvePage/ProblemSection/parseProblemInfo.ts
@@ -1,0 +1,86 @@
+interface ProblemData {
+  title?: string | null;
+  text?: string | null;
+  code?: string | null;
+  domString?: string | null;
+}
+
+const parseProblemInfo = (problemInfoHtml: string | undefined) => {
+  if (!problemInfoHtml) return;
+  // HTML 파싱
+  const parser = new DOMParser();
+  const $problemInfo = parser.parseFromString(problemInfoHtml, 'text/html');
+  // 문제 정보 body 부분을 추출한다.
+  const $problemBody = $problemInfo.querySelector('#problem-body');
+  // 각 세부 정보를 추출한다.
+  const $description = $problemBody?.querySelector('#description h2');
+  const $problemDescription = $problemBody?.querySelector(
+    '#problem_description'
+  );
+  const $input = $problemBody?.querySelector('#input h2');
+  const $problemInput = $problemBody?.querySelector('#problem_input p');
+  const $output = $problemBody?.querySelector('#output h2');
+  const $problemOutput = $problemBody?.querySelector('#problem_output p');
+  const $limit = $problemBody?.querySelector('#limit h2');
+  const $problemLimit = $problemBody?.querySelector('#problem_limit ul');
+
+  const $sampleInputs = $problemBody?.querySelectorAll(
+    'section[id^=sampleinput]'
+  );
+  const $sampleOuputs = $problemBody?.querySelectorAll(
+    'section[id^=sampleoutput]'
+  );
+
+  const sampleInputs = Array.prototype.slice.call($sampleInputs);
+  const sampleOuputs = Array.prototype.slice.call($sampleOuputs);
+
+  // 문제, 입력, 출력, 제한조건을 객체 배열 형태로 변환한다.
+  const problemInfoList: ProblemData[] = [
+    {
+      title: $description?.textContent,
+      domString: $problemDescription?.innerHTML.trim(),
+    },
+    {
+      title: $input?.textContent,
+      text: $problemInput?.textContent,
+    },
+    {
+      title: $output?.textContent,
+      text: $problemOutput?.textContent,
+    },
+    {
+      title: $limit?.textContent,
+      domString: $problemLimit?.outerHTML.trim(),
+    },
+  ];
+
+  // 예제 입출력
+  Array.from({ length: sampleInputs.length }, (_, i) => i).forEach(index => {
+    const sampleInput = sampleInputs[index];
+    const sampleOutput = sampleOuputs[index];
+
+    const sampleInputHeadline = sampleInput
+      .querySelector('h2')
+      ?.innerText.replace('복사', '');
+    const sampleInputData = sampleInput.querySelector('pre')?.textContent;
+
+    const sampleOutputHeadline = sampleOutput
+      .querySelector('h2')
+      ?.innerText.replace('복사', '');
+    const sampleOutputData = sampleOutput.querySelector('pre')?.textContent;
+
+    problemInfoList.push({
+      title: sampleInputHeadline,
+      code: sampleInputData,
+    });
+
+    problemInfoList.push({
+      title: sampleOutputHeadline,
+      code: sampleOutputData,
+    });
+  });
+
+  return problemInfoList;
+};
+
+export default parseProblemInfo;

--- a/src/pages/ProblemSolvePage/ProblemSolvePage.style.ts
+++ b/src/pages/ProblemSolvePage/ProblemSolvePage.style.ts
@@ -12,6 +12,31 @@ const ContentsWrapper = styled(Row)`
   height: 100%;
 `;
 
+const ProblemLinkContainer = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    justify-content: end;
+    padding: 0.5rem;
+    background-color: ${theme.color.background_editor};
+  `}
+`;
+
+const ProblemLinkText = styled.span`
+  ${({ theme }) => css`
+    font-weight: ${theme.fontWeight.semiBold};
+  `}
+`;
+
+const ProblemLink = styled.a`
+  ${({ theme }) => css`
+    font-weight: ${theme.fontWeight.medium};
+    cursor: pointer;
+    &:hover {
+      color: ${theme.color.gray_30};
+    }
+  `}
+`;
+
 const EditorWrapper = styled(Col)`
   height: 100%;
 `;
@@ -26,4 +51,12 @@ const ButtonWrapper = styled(Row)`
   `}
 `;
 
-export { ButtonWrapper, ContentsWrapper, EditorWrapper, Wrapper };
+export {
+  ButtonWrapper,
+  ContentsWrapper,
+  EditorWrapper,
+  ProblemLink,
+  ProblemLinkContainer,
+  ProblemLinkText,
+  Wrapper,
+};

--- a/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
@@ -3,6 +3,7 @@ import { Panel, PanelGroup } from 'react-resizable-panels';
 import { Button, CodeEditor, ResizeHandle } from '@/components';
 import { useCustomTheme } from '@/hooks/useCustomTheme';
 import { useCompile, useSubmission } from '@/hooks/useProblemSolve';
+import useRoomStore from '@/store/RoomStore';
 import useTimerStore from '@/store/TimerStore';
 
 import { DIRECTION, MOCK_DATA, SIZE_PERCENTAGE } from './constants';
@@ -13,6 +14,7 @@ import * as S from './ProblemSolvePage.style';
 export default function ProblemSolvePage() {
   const { theme } = useCustomTheme();
 
+  const { roomData } = useRoomStore();
   const { mutate: compileMutate } = useCompile();
   const { mutate: submitMutate } = useSubmission();
 
@@ -27,12 +29,26 @@ export default function ProblemSolvePage() {
     setIsStop(false);
   };
 
+  const handleClickProblemLink = () => {
+    if (!roomData.problemLink) return;
+
+    window.open(roomData.problemLink, '_blank', 'noopener');
+  };
+
   return (
     <S.Wrapper>
       <S.ContentsWrapper>
         <PanelGroup direction={DIRECTION.HORIZONTAL}>
           <Panel defaultSize={SIZE_PERCENTAGE.PROBLEM}>
             {/* 문제 영역 */}
+            <S.ProblemLinkContainer>
+              <S.ProblemLinkText>
+                문제 출처 :{' '}
+                <S.ProblemLink onClick={handleClickProblemLink}>
+                  {roomData.problemLink}
+                </S.ProblemLink>
+              </S.ProblemLinkText>
+            </S.ProblemLinkContainer>
             <ProblemSection />
           </Panel>
           <ResizeHandle direction={DIRECTION.HORIZONTAL} />

--- a/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
@@ -32,7 +32,7 @@ export default function ProblemSolvePage() {
   const handleClickProblemLink = () => {
     if (!roomData.problemLink) return;
 
-    window.open(roomData.problemLink, '_blank', 'noopener');
+    window.open(roomData.problemLink, '_blank', 'noopener,noreferrer');
   };
 
   return (

--- a/src/pages/RoomPage/TestInfo/TestInfo.tsx
+++ b/src/pages/RoomPage/TestInfo/TestInfo.tsx
@@ -68,7 +68,7 @@ export default function TestInfo({ className, myRoomData }: TestInfoProps) {
   const handleClickLink = () => {
     if (!problemLink) return;
 
-    window.open(problemLink, '_blank', 'noopener');
+    window.open(problemLink, '_blank', 'noopener,noreferrer');
   };
 
   return (

--- a/src/services/Problem/getProblemInfo.ts
+++ b/src/services/Problem/getProblemInfo.ts
@@ -1,0 +1,22 @@
+import { API_ENDPOINT } from '../apiEndpoint';
+import { axiosAuthInstance } from '../axiosInstance';
+
+interface GetProblemResponse {
+  success: boolean;
+  response: {
+    problemInfoHtml: string;
+  };
+}
+
+const getProblemInfo = async (problemLink: string) => {
+  return await axiosAuthInstance.get<GetProblemResponse>(
+    `${API_ENDPOINT.PROBLEM.PROBLEM_INFO}`,
+    {
+      params: {
+        problemLink,
+      },
+    }
+  );
+};
+
+export default getProblemInfo;

--- a/src/services/apiEndpoint.ts
+++ b/src/services/apiEndpoint.ts
@@ -18,6 +18,9 @@ export const API_ENDPOINT = {
     PUBLICATION: '/publication',
     SUBSCRIPTION: '/subscription',
   },
+  PROBLEM: {
+    PROBLEM_INFO: '/v1/problems/html',
+  },
 };
 export const EDIT_MY_INFO_URL = '/v1/members/my/general';
 export const EDIT_MY_PASSWORD = '/v1/members/my/password';


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->
Problem Solve 페이지에서 크롤링한 백준 문제 정보를 표시합니다.

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 💻 작업 내용

<!-- PR 본문을 입력하세요. -->
###  레이아웃
- 1004번 어린왕자 문제 표시 예시
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/d791b14f-c5c7-47b4-9dea-65acf7f6a3f6)
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/aaa0f461-e79d-4f7d-ab30-0789b21c575d)
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/87bc35fd-fd1d-4ef2-b120-6e7253f34d58)

### 핵심 추가 및 변경사항
- 문제 크롤링 API 관련 함수 및 커스텀 훅 구현
  - `getProblemInfo`, `useProblem`
- 크롤링한 문제 HTML 문자열을 파싱하고 이를 객체 배열 형태로 변환하는 `parseProblemInfo` 함수를 구현
- `dangerouslySetInnerHTML` 속성을 활용해 파싱한 DOM을 렌더링
- 문제 링크를 우측 상단에 표시
  - 혹시나 문제 크롤링에서 문제가 발생해서 이미지 오류나 문제 조건이 제대로 나타나지 않을 것을 대비했습니다.
  - noopener, noreferrer 옵션을 추가해 링크 이동 시 보안 설정을 추가했습니다. [관련 레퍼런스](https://dev-handbook.tistory.com/44)

## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->

- 문제 정보가 제대로 렌더링되는지 확인 부탁드립니다!
- 문제 영역의 높이가 길어져 화면 전체 영역을 침범하는 이슈는 아래 PR에서 처리하기로 논의했었습니다.
https://github.com/1e5i-Shark/algobaro-fe/pull/97

