### PR TITLE
[✨feat]: 코드 에디터 언어별 기본값 추가 및 관련 설정 변경

### DIFF
--- a/src/components/Common/DropDown/DropDown.tsx
+++ b/src/components/Common/DropDown/DropDown.tsx
@@ -148,7 +148,7 @@ export default function DropDown({
           }}
         >
           {/* 선택 메뉴 영역 */}
-          {!hasDefaultLabel && <MenuItem value="">선택 없음</MenuItem>}
+          {hasDefaultLabel && <MenuItem value="">선택 없음</MenuItem>}
           {dataKeys.map(dataKey => {
             return (
               <MenuItem

--- a/src/components/IDE/CodeEditor/CodeEditor.tsx
+++ b/src/components/IDE/CodeEditor/CodeEditor.tsx
@@ -1,6 +1,6 @@
 import './CodeEditorLibs';
 
-import { Editor } from 'codemirror';
+import { Editor, EditorChange } from 'codemirror';
 import { useEffect, useRef } from 'react';
 import { UnControlled as CodeMirrorEditor } from 'react-codemirror2';
 import { CodemirrorBinding } from 'y-codemirror';
@@ -13,12 +13,18 @@ import { useCustomTheme } from '@/hooks/useCustomTheme';
 import useCodeEditorStore from '@/store/CodeEditorStore';
 
 import * as S from './CodeEditor.style';
-import { getEditorMode, getRandomColors } from './utils';
+import {
+  codeEditorDefaultValue,
+  getEditorMode,
+  getRandomColors,
+} from './utils';
 
 interface CodeEditorProps {
+  mode?: 'normal' | 'codeShare' | 'readonly';
   roomUuid?: string;
   width?: string;
   height?: string;
+  defaultValue?: string;
 }
 
 /**
@@ -29,9 +35,11 @@ interface CodeEditorProps {
  * @param [height] - `옵션`
  */
 export default function CodeEditor({
+  mode = 'normal',
   roomUuid,
   width,
   height,
+  defaultValue = '',
 }: CodeEditorProps) {
   const { theme } = useCustomTheme();
 
@@ -69,53 +77,74 @@ export default function CodeEditor({
     });
   };
 
-  useEffect(() => {
-    try {
-      // 에디터 영역 CodeMirror, 텍스트를 관리하는 yText, 사용자 감지 awareness를 연동
-      connectCodeMirror();
+  // 코드 share 모드 일 때만 yjs와 codeMirror를 연결
+  if (mode === 'codeShare') {
+    useEffect(() => {
+      try {
+        // 에디터 영역 CodeMirror, 텍스트를 관리하는 yText, 사용자 감지 awareness를 연동
+        connectCodeMirror();
 
-      // text 변경 감지
-      const yTextListener = () => {
-        const newContent = yText.toString();
-        // 전역 Store의 code 변경
-        setCode(newContent);
+        // text 변경 감지
+        const yTextListener = () => {
+          const newContent = yText.toString();
+          // 전역 Store의 code 변경
+          setCode(newContent);
+        };
+
+        yText.observe(yTextListener);
+      } catch (err) {
+        // TODO: 연결이 끊어진 경우 처리 필요
+        console.error('webrtc 연결이 끊어졌습니다.');
+      }
+
+      return () => {
+        if (!providerRef.current) return;
+
+        providerRef.current.disconnect();
+        yDoc.destroy();
       };
+    }, []);
+  }
 
-      yText.observe(yTextListener);
-    } catch (err) {
-      // TODO: 연결이 끊어진 경우 처리 필요
-      console.error('webrtc 연결이 끊어졌습니다.');
-    }
-
-    return () => {
-      if (!providerRef.current) return;
-
-      providerRef.current.disconnect();
-      yDoc.destroy();
+  // 코드 에디터 코드 변화 감지 이벤트 핸들러 함수
+  const handleChangeCode = (
+    editor: Editor,
+    data: EditorChange,
+    value: string
+  ) => {
+    const changeEditorParams = {
+      editor,
+      data,
+      value,
     };
-  }, []);
+    setCode(changeEditorParams.value);
+  };
 
   return (
     <S.Wrapper>
-      <S.DropDownWrapper>
-        <S.DefaultGutter className="gutter" />
-        <DropDown
-          width="fit-content"
-          dataId="languages"
-          labelId="languages-label"
-          defaultValue={language}
-          dataSet={PROBLEM_LANGUAGES_DATA_SET}
-          onSelected={value => {
-            setLanguage(value);
-          }}
-          borderColor={theme.color.gray_50}
-          fontSize={theme.size.S}
-          backgroundColor={theme.color.background_editor}
-          hasDefaultLabel={false}
-        />
-      </S.DropDownWrapper>
+      {mode !== 'readonly' && (
+        <S.DropDownWrapper>
+          <S.DefaultGutter className="gutter" />
+          <DropDown
+            width="fit-content"
+            dataId="languages"
+            labelId="languages-label"
+            defaultValue={language}
+            dataSet={PROBLEM_LANGUAGES_DATA_SET}
+            onSelected={value => {
+              setLanguage(value);
+            }}
+            borderColor={theme.color.gray_50}
+            fontSize={theme.size.S}
+            backgroundColor={theme.color.background_editor}
+            hasDefaultLabel={false}
+          />
+        </S.DropDownWrapper>
+      )}
       <CodeMirrorEditor
+        onChange={handleChangeCode}
         options={{
+          value: defaultValue || codeEditorDefaultValue[language],
           mode: getEditorMode(language),
           theme: theme.mode === 'dark' ? 'material-palenight' : 'eclipse',
           lineNumbers: true,
@@ -124,6 +153,7 @@ export default function CodeEditor({
             'Ctrl-Space': 'autocomplete',
           },
           gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
+          readOnly: mode === 'readonly' ? 'nocursor' : false,
         }}
         editorDidMount={(editor: Editor) => {
           editorRef.current = editor;

--- a/src/components/IDE/CodeEditor/utils.ts
+++ b/src/components/IDE/CodeEditor/utils.ts
@@ -1,7 +1,7 @@
 export const LANGUAGES = {
+  JAVASCRIPT: 'JAVASCRIPT',
   JAVA: 'JAVA',
   PYTHON: 'PYTHON',
-  JAVASCRIPT: 'JAVASCRIPT',
   'C++': 'C++',
 } as const;
 
@@ -25,4 +25,44 @@ export const getEditorMode = (language: string) => {
 export const getRandomColors = () => {
   const randomColor = Math.floor(Math.random() * 16777215).toString(16);
   return `#${randomColor}`;
+};
+
+interface CodeEditorDefaultValue {
+  [key: string]: string;
+}
+
+export const codeEditorDefaultValue: CodeEditorDefaultValue = {
+  cpp: `// 백준 1000번 예제 소스 코드
+#include <iostream>
+using namespace std;
+int main() {
+	int a, b;
+	cin >> a >> b;
+	cout << a+b << endl;
+	return 0;
+}`,
+  java: `import java.util.*;
+public class Main{
+  public static void main(String args[]){
+    Scanner sc = new Scanner(System.in);
+    int a, b;
+    a = sc.nextInt();
+    b = sc.nextInt();
+    System.out.println(a + b);
+  }
+}`,
+  python3: `# 백준 1000번 예제 소스 코드
+a, b = map(int, input().split())
+print(a+b)`,
+  nodejs: `// 한 줄 입력
+// 백준 1000번 예제 소스 코드
+let fs = require('fs');
+let input = fs.readFileSync('/dev/stdin').toString().trim().split(' ');
+let a = parseInt(input[0]);
+let b = parseInt(input[1]);
+console.log(a + b);
+
+// 여러 줄 입력
+let fs = require('fs');
+let input = fs.readFileSync('/dev/stdin').toString().trim().split('\\n');`,
 };

--- a/src/constants/room.ts
+++ b/src/constants/room.ts
@@ -30,8 +30,8 @@ export const MOCK_ROOM_DATA = {
 };
 
 export const PROBLEM_LANGUAGES_DATA_SET: Record<string, string> = {
-  java: 'Java',
-  python3: 'Python',
   nodejs: 'JavaScript',
+  python3: 'Python',
+  java: 'Java',
   cpp: 'C++',
 };

--- a/src/pages/ProblemSharePage/ProblemSharePage.tsx
+++ b/src/pages/ProblemSharePage/ProblemSharePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { CodeEditor } from '@/components';
 import { MOCK_ROOM_DATA } from '@/constants/room';
+import useCodeEditorStore from '@/store/CodeEditorStore';
 import useTimerStore from '@/store/TimerStore';
 
 import { MOCK_USER_DATA } from './constants';
@@ -15,6 +16,7 @@ const myInfo = MOCK_USER_DATA.find(user => user.id === myId);
 export default function ProblemSharePage() {
   const [selectedUser, setSelectedUser] = useState(myInfo);
   const { setIsStop, setIsEnd } = useTimerStore(state => state);
+  const { code } = useCodeEditorStore();
 
   const handleUserClick = (userId: string) => {
     const filteredUser = userData.find(user => user.id === userId);
@@ -35,7 +37,11 @@ export default function ProblemSharePage() {
         onUserClick={handleUserClick}
       />
       <S.CodeEditorWrapper>
-        <CodeEditor roomUuid={MOCK_ROOM_DATA.roomShortUuid} />
+        <CodeEditor
+          defaultValue={code}
+          mode="readonly"
+          roomUuid={MOCK_ROOM_DATA.roomShortUuid}
+        />
       </S.CodeEditorWrapper>
     </S.Wrapper>
   );

--- a/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
@@ -25,26 +25,12 @@ export default function ProblemSolvePage() {
   const { mutate: submitMutate } = useSubmission();
 
   const { input, code, language } = useCodeEditorStore(state => state);
-  // 코드 에디터에 내용 미작성 여부 체크하는 로직이다.
-  const checkEmptyCode = () => {
-    if (code.trim() === '') {
-      alert('내용을 입력해주세요.');
-      return true;
-    }
-
-    return false;
-  };
 
   const handleCompileExecution = async () => {
-    checkEmptyCode();
-
     compileMutate({ code, input, language });
   };
 
   const handleSubmit = () => {
-    // 코드 에디터 미작성 여부 체크
-    const isEmptyCode = checkEmptyCode();
-    if (isEmptyCode) return;
     // TODO: 코드 제출 시 백준 submit 링크 직접 제출 확인 모달 추가
 
     navigate(`/problemshare/${roomShortUuid}`);

--- a/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
@@ -1,7 +1,7 @@
 import { Panel, PanelGroup } from 'react-resizable-panels';
+import { useNavigate } from 'react-router-dom';
 
 import { Button, CodeEditor, ResizeHandle } from '@/components';
-import { MOCK_ROOM_DATA } from '@/constants/room';
 import { useCustomTheme } from '@/hooks/useCustomTheme';
 import { useCompile, useSubmission } from '@/hooks/useProblemSolve';
 import useCodeEditorStore from '@/store/CodeEditorStore';
@@ -15,23 +15,24 @@ import * as S from './ProblemSolvePage.style';
 export default function ProblemSolvePage() {
   const { theme } = useCustomTheme();
 
-  // TODO: roomStore에서 가져오도록 수정
-  const roomShortUuid = MOCK_ROOM_DATA.roomShortUuid;
+  const navigate = useNavigate();
 
-  // TODO: 문제 링크를 가져오도록 수정
-  const MOCK_PROBLEM_LINK = 'https://www.acmicpc.net/problem/1000';
+  const { roomData } = useRoomStore();
+  const roomShortUuid = roomData.roomShortUuid;
+  const problemLink = roomData.problemLink;
 
   const { mutate: compileMutate, isLoading: isCompileLoading } = useCompile();
-  const { roomData } = useRoomStore();
   const { mutate: submitMutate } = useSubmission();
 
   const { input, code, language } = useCodeEditorStore(state => state);
-
+  // 코드 에디터에 내용 미작성 여부 체크하는 로직이다.
   const checkEmptyCode = () => {
     if (code.trim() === '') {
       alert('내용을 입력해주세요.');
-      return;
+      return true;
     }
+
+    return false;
   };
 
   const handleCompileExecution = async () => {
@@ -41,20 +42,25 @@ export default function ProblemSolvePage() {
   };
 
   const handleSubmit = () => {
-    checkEmptyCode();
+    // 코드 에디터 미작성 여부 체크
+    const isEmptyCode = checkEmptyCode();
+    if (isEmptyCode) return;
+    // TODO: 코드 제출 시 백준 submit 링크 직접 제출 확인 모달 추가
+
+    navigate(`/problemshare/${roomShortUuid}`);
 
     submitMutate({
       roomShortUuid,
       language,
       code,
-      problemLink: MOCK_PROBLEM_LINK,
+      problemLink,
     });
   };
 
   const handleClickProblemLink = () => {
-    if (!roomData.problemLink) return;
+    if (!problemLink) return;
 
-    window.open(roomData.problemLink, '_blank', 'noopener,noreferrer');
+    window.open(problemLink, '_blank', 'noopener,noreferrer');
   };
 
   return (
@@ -67,7 +73,7 @@ export default function ProblemSolvePage() {
               <S.ProblemLinkText>
                 문제 출처 :{' '}
                 <S.ProblemLink onClick={handleClickProblemLink}>
-                  {roomData.problemLink}
+                  {problemLink}
                 </S.ProblemLink>
               </S.ProblemLinkText>
             </S.ProblemLinkContainer>


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->
코드 데이터의 언어별 기본값을 설정하고 일부 관련 설정을 변경했습니다.

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가

## 💻 작업 내용

<!-- PR 본문을 입력하세요. -->
### 핵심 구현 및 변경사항
- 드롭다운에서 언어를 선택하면 해당 언어에 대한 기본 코드가 제공됩니다.
  - 자바스크립트 선택 예시
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/6bcb0342-e227-4a1f-8f83-e6dde2e76627)

- 코드 에디터 드롭다운에서 선택없음 메뉴를 삭제했습니다.
- 코드 에디터 입력 모드를 추가했습니다.
  - `normal`, `codeShare`, `readonly`로 나누었습니다.
  - 코드 공유 페이지의 코드 에디터는 MVP 상으로 `readonly`로 우선 변경했습니다. 
- 코드 에디터의 입력값을 `useCodeEditorStore`에 onChange 이벤트로 연동했습니다.
- 코드를 미작성했는지 여부를 체크하여 코드가 빈 채로 최종 제출되는 것을 방지했고 최종 제출 시 공유 페이지로 이동하는 로직을 추가했습니다.


## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
- 언어별 기본 코드가 적절한지 확인바랍니다.
- 코드 제출 시 백준 submit 링크와 작성한 코드를 모달로 보여주어 직접 사용자가 확인하는 로직을 추가해야 합니다.
- 풀이 페이지에서 공유 페이지로 넘어갈 때 작성한 코드가 잘 유지되어 넘어가는지 확인바랍니다.