### PR TITLE
[✨feat]: 코드 에디터 붙여넣기 방지 코드 추가

### DIFF
--- a/src/components/IDE/CodeEditor/CodeEditor.tsx
+++ b/src/components/IDE/CodeEditor/CodeEditor.tsx
@@ -27,6 +27,10 @@ interface CodeEditorProps {
   defaultValue?: string;
 }
 
+interface CustomEditorChange extends EditorChange {
+  cancel?: () => void;
+}
+
 /**
  * 코드 에디터
  * roomUuid를 넘겨주는 경우, 공동 편집 코드 에디터를 사용할 수 있습니다.
@@ -120,6 +124,27 @@ export default function CodeEditor({
     setCode(changeEditorParams.value);
   };
 
+  // 코드 에디터 붙여넣기 방지 함수
+  const handlePreventCopy = (
+    editor: Editor,
+    data: CustomEditorChange,
+    value: string,
+    next: () => void
+  ) => {
+    const beforeChangeEventProps = {
+      editor,
+      data,
+      value,
+      next,
+    };
+
+    const changeData = beforeChangeEventProps.data;
+    if (changeData.origin === 'paste' && mode === 'normal') {
+      changeData.cancel?.();
+      alert('풀이 중 코드 붙여넣기는 금지합니다.');
+    }
+  };
+
   return (
     <S.Wrapper>
       {mode !== 'readonly' && (
@@ -143,6 +168,7 @@ export default function CodeEditor({
       )}
       <CodeMirrorEditor
         onChange={handleChangeCode}
+        onBeforeChange={handlePreventCopy}
         options={{
           value: defaultValue || codeEditorDefaultValue[language],
           mode: getEditorMode(language),

--- a/src/store/CodeEditorStore/index.ts
+++ b/src/store/CodeEditorStore/index.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
+import { codeEditorDefaultValue } from '@/components/IDE/CodeEditor/utils';
+
 interface Props {
   code: string;
   language: string;
@@ -13,13 +15,12 @@ interface Props {
 }
 
 // TODO: 서버로부터 데이터 받아와서 교체 필요
-const MOCK_LANGUAGE = 'nodejs';
 const MOCK_INPUT = '1 2';
 
 const useCodeEditorStore = create<Props>()(
   devtools(set => ({
-    code: '',
-    language: MOCK_LANGUAGE,
+    code: codeEditorDefaultValue.nodejs,
+    language: 'nodejs',
     input: MOCK_INPUT,
     result: '',
     setCode: (code: string) => set({ code }),


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->
코드 에디터 내에서 붙여넣기를 못하도록 방지했습니다.

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가

## 💻 작업 내용

<!-- PR 본문을 입력하세요. -->
- `onBeforeChange` 이벤트 props를 통해 에디터 내에서 ctrl + v 동작이 불가능하도록 막았습니다.
  - 붙여넣기를 시도하면 alert를 표시합니다.
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/7d9330ef-9977-4719-a6d0-b17fadc1caee)

- 코드 전역 상태 훅 `useCodeEditorStore`에서 `code`의 기본값이 `''` 빈 값으로 설정되어 있어서 코드를 입력하지 않고 실행 및 제출할 때 문제가 생기는 이슈가 있었습니다.
  - 초기값을 `codeEditorDefaultValue.nodejs` 자바스크립트 언어 기본 코드로 설정해서 이를 해결했습니다.

## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
- 이외 추가해야 할 단축키나 이벤트 기능이 있다면 알려주세요!