### PR TITLE
[✨feat]: Status 드롭다운 추가, API에 맞춰서 레이아웃 수정

### DIFF
--- a/src/pages/ProblemSharePage/ProblemSharePage.style.ts
+++ b/src/pages/ProblemSharePage/ProblemSharePage.style.ts
@@ -23,7 +23,9 @@ const SolveStatusWrapper = styled.div`
   ${({ theme }) => css`
     display: flex;
     justify-content: start;
+    margin-bottom: 1rem;
     font-weight: ${theme.fontWeight.semiBold};
+    color: ${theme.color.white_primary};
   `}
 `;
 

--- a/src/pages/ProblemSharePage/ProblemSharePage.tsx
+++ b/src/pages/ProblemSharePage/ProblemSharePage.tsx
@@ -85,7 +85,7 @@ export default function ProblemSharePage() {
             roomUuid={MOCK_ROOM_DATA.roomShortUuid}
           />
         ) : (
-          <S.NoResultText>풀이 내역이 존재하지 않습니다</S.NoResultText>
+          <S.NoResultText>아직 문제를 풀고 있어요 📝</S.NoResultText>
         )}
       </S.CodeEditorWrapper>
     </S.Wrapper>

--- a/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
@@ -9,6 +9,7 @@ import useModal from '@/hooks/useModal';
 import { useCompile } from '@/hooks/useProblemSolve';
 import useCodeEditorStore from '@/store/CodeEditorStore';
 import useRoomStore from '@/store/RoomStore';
+import useTimerStore from '@/store/TimerStore';
 
 import { DIRECTION, SIZE_PERCENTAGE } from './constants';
 import ProblemExecution from './ProblemExecution/ProblemExecution';
@@ -37,6 +38,7 @@ export default function ProblemSolvePage() {
     roomData: { problemLink },
     setRoomData,
   } = useRoomStore(state => state);
+  const { isEnd } = useTimerStore(state => state);
 
   const handleClickProblemLink = () => {
     if (!problemLink) return;
@@ -57,6 +59,14 @@ export default function ProblemSolvePage() {
       setRoomData(roomDetail.response);
     }
   }, [roomDetail]);
+
+  useEffect(() => {
+    if (isEnd) {
+      openModal();
+    } else {
+      closeModal();
+    }
+  }, [isEnd]);
 
   useEffect(() => {
     refetch();

--- a/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.style.ts
+++ b/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.style.ts
@@ -5,7 +5,7 @@ import { Col, Row } from '@/styles/GlobalStyle';
 
 const Wrapper = styled(Col)`
   gap: 4rem;
-  min-width: 60rem;
+  min-width: 65rem;
   padding: 4rem 4rem 0rem;
 `;
 
@@ -17,45 +17,6 @@ const Title = styled.p`
   `};
 `;
 
-const TestResultWrapper = styled.div`
-  height: 4rem;
-  text-align: center;
-  white-space: pre-line;
-`;
-
-const TestErrorText = styled.span`
-  ${({ theme }) => css`
-    line-height: ${theme.size.XXL};
-    color: ${theme.color.red};
-  `};
-`;
-
-const TestCaseWrapper = styled.div``;
-
-const TestCaseList = styled.ul`
-  display: flex;
-  flex-direction: column;
-`;
-
-const TestCaseItem = styled.li`
-  display: flex;
-  align-items: center;
-  height: 3rem;
-`;
-
-const LottieWrapper = styled(Row)`
-  justify-content: center;
-  width: 5rem;
-`;
-
-const TestCaseTitle = styled.p`
-  ${({ theme }) => css`
-    width: 8rem;
-    font-size: 1.6rem;
-    font-weight: ${theme.fontWeight.medium};
-  `};
-`;
-
 const BOJWrapper = styled.div`
   white-space: pre-line;
 `;
@@ -64,6 +25,7 @@ const BOJGuideText = styled.p`
   ${({ theme }) => css`
     margin-top: 2.2rem;
     line-height: ${theme.size.XXL};
+    color: ${theme.color.text_primary_color};
     text-align: center;
   `};
 `;
@@ -87,13 +49,6 @@ export {
   BOJGuideText,
   BOJWrapper,
   EndButtonWrapper,
-  LottieWrapper,
-  TestCaseItem,
-  TestCaseList,
-  TestCaseTitle,
-  TestCaseWrapper,
-  TestErrorText,
-  TestResultWrapper,
   Title,
   Wrapper,
 };

--- a/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.tsx
@@ -6,12 +6,9 @@ import { Button, Modal, Spinner } from '@/components';
 import { useCustomTheme } from '@/hooks/useCustomTheme';
 import { useSubmission } from '@/hooks/useProblemSolve';
 import { PATH } from '@/routes/path';
-import { TestCaseResultType } from '@/services/ProblemSolve/submission';
 import useCodeEditorStore from '@/store/CodeEditorStore';
 import useRoomStore from '@/store/RoomStore';
 
-import failLottie from './lottie/fail-lottie.json';
-import successLottie from './lottie/success-lottie.json';
 import * as S from './ProblemSubmitModal.style';
 
 interface ProblemSubmitModalProps {
@@ -30,9 +27,6 @@ export default function ProblemSubmitModal({
   const { roomShortUuid, problemLink } = useRoomStore(state => state.roomData);
   const { code, language } = useCodeEditorStore(state => state);
 
-  const [testCaseResult, setTestCaseResult] = useState<TestCaseResultType[]>(
-    []
-  );
   const [isSubmitDisabled, setIsSubmitDisabled] = useState(true);
 
   const { mutateAsync: submitMutateAsync, isLoading } = useSubmission();
@@ -95,41 +89,6 @@ export default function ProblemSubmitModal({
       onClose={closeModal}
     >
       <S.Wrapper>
-        <S.TestCaseWrapper>
-          <S.Title>채점 결과</S.Title>
-          {testCaseResult.length === 0 && (
-            <S.TestResultWrapper>
-              {isLoading ? (
-                <Spinner />
-              ) : (
-                <S.TestErrorText>{`실행 중 오류가 발생했습니다 \n 잠시 후 다시 시도해주세요`}</S.TestErrorText>
-              )}
-            </S.TestResultWrapper>
-          )}
-          {testCaseResult.length > 0 && (
-            <S.TestCaseList>
-              {testCaseResult.map((result, index) => (
-                <S.TestCaseItem key={index}>
-                  <S.TestCaseTitle>{`TestCase ${index + 1}:`}</S.TestCaseTitle>
-                  <S.LottieWrapper>
-                    <Lottie
-                      width={result.success ? 100 : 21}
-                      height={result.success ? 100 : 21}
-                      options={{
-                        loop: false,
-                        autoplay: true,
-                        animationData: result.success
-                          ? successLottie
-                          : failLottie,
-                      }}
-                      style={{ margin: '0' }}
-                    />
-                  </S.LottieWrapper>
-                </S.TestCaseItem>
-              ))}
-            </S.TestCaseList>
-          )}
-        </S.TestCaseWrapper>
         <S.BOJWrapper>
           <S.Title>백준 제출하기</S.Title>
           <S.BOJGuideText>{`백준 사이트에 제출하여 채점 결과를 확인해 보세요!

--- a/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from 'react';
-import Lottie from 'react-lottie';
 import { useNavigate } from 'react-router-dom';
 
-import { Button, Modal, Spinner } from '@/components';
+import { Button, DropDown, Modal } from '@/components';
 import { useCustomTheme } from '@/hooks/useCustomTheme';
 import { useSubmission } from '@/hooks/useProblemSolve';
 import { PATH } from '@/routes/path';
 import useCodeEditorStore from '@/store/CodeEditorStore';
 import useRoomStore from '@/store/RoomStore';
 
+import { STATUS_DATA_SET } from '../constants';
 import * as S from './ProblemSubmitModal.style';
 
 interface ProblemSubmitModalProps {
@@ -28,8 +28,9 @@ export default function ProblemSubmitModal({
   const { code, language } = useCodeEditorStore(state => state);
 
   const [isSubmitDisabled, setIsSubmitDisabled] = useState(true);
+  const [solveStatus, setSolveStatus] = useState('SUCCESS');
 
-  const { mutateAsync: submitMutateAsync, isLoading } = useSubmission();
+  const { mutateAsync: submitMutateAsync } = useSubmission();
 
   const navigate = useNavigate();
 
@@ -54,35 +55,26 @@ export default function ProblemSubmitModal({
     }, 800);
   };
 
-  const handleEndCoding = () => {
-    navigate(`${PATH.PROBLEMSHARE}/${roomShortUuid}`);
-  };
-
-  const handleSubmit = async () => {
-    const result = await submitMutateAsync({
+  const handleEndCoding = async () => {
+    await submitMutateAsync({
       roomShortUuid,
       language,
       code,
       problemLink,
+      solveStatus,
     });
-
-    if (result.response?.testCaseResults) {
-      setTestCaseResult(result.response.testCaseResults);
-    }
+    navigate(`${PATH.PROBLEMSHARE}/${roomShortUuid}`);
   };
 
   useEffect(() => {
     if (isOpen) {
-      handleSubmit();
       setIsSubmitDisabled(true);
-    } else {
-      setTestCaseResult([]);
     }
   }, [isOpen]);
 
   return (
     <Modal
-      width="60rem"
+      width="65rem"
       height="fit-content"
       ref={modalRef}
       isOpen={isOpen}
@@ -90,9 +82,8 @@ export default function ProblemSubmitModal({
     >
       <S.Wrapper>
         <S.BOJWrapper>
-          <S.Title>백준 제출하기</S.Title>
-          <S.BOJGuideText>{`백준 사이트에 제출하여 채점 결과를 확인해 보세요!
-          제출이 완료되어야 서비스를 정상적으로 이용할 수 있어요`}</S.BOJGuideText>
+          <S.Title>제출하기</S.Title>
+          <S.BOJGuideText>{`백준 사이트에 제출하여 채점 결과를 확인해 보세요!`}</S.BOJGuideText>
           <S.BOJButtonWrapper>
             <Button
               width="16rem"
@@ -102,6 +93,24 @@ export default function ProblemSubmitModal({
             >
               백준 제출하러 가기
             </Button>
+          </S.BOJButtonWrapper>
+          <S.Title>결과 공유하기</S.Title>
+          <S.BOJGuideText>{`팀원들에게 백준 채점 결과를 공유해 주세요 🤗`}</S.BOJGuideText>
+          <S.BOJButtonWrapper>
+            <DropDown
+              width="16rem"
+              dataId="submitStatus"
+              labelId="status-label"
+              defaultValue={'SUCCESS'}
+              dataSet={STATUS_DATA_SET}
+              onSelected={value => {
+                setSolveStatus(value);
+              }}
+              borderColor={theme.color.gray_50}
+              fontSize={theme.size.M}
+              backgroundColor={theme.color.background_editor}
+              hasDefaultLabel={false}
+            />
           </S.BOJButtonWrapper>
           <S.EndButtonWrapper>
             <Button

--- a/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.tsx
@@ -63,7 +63,7 @@ export default function ProblemSubmitModal({
       problemLink,
       solveStatus,
     });
-    navigate(`${PATH.PROBLEMSHARE}/${roomShortUuid}`);
+    navigate(`${PATH.PROBLEMSHARE}/${roomShortUuid}`, { replace: true });
   };
 
   useEffect(() => {

--- a/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.tsx
@@ -95,7 +95,7 @@ export default function ProblemSubmitModal({
             </Button>
           </S.BOJButtonWrapper>
           <S.Title>결과 공유하기</S.Title>
-          <S.BOJGuideText>{`팀원들에게 백준 채점 결과를 공유해 주세요 🤗`}</S.BOJGuideText>
+          <S.BOJGuideText>{`팀원들에게 채점 결과를 공유해 주세요 🤗`}</S.BOJGuideText>
           <S.BOJButtonWrapper>
             <DropDown
               width="16rem"

--- a/src/pages/ProblemSolvePage/ProblemTimer/ProblemTimer.tsx
+++ b/src/pages/ProblemSolvePage/ProblemTimer/ProblemTimer.tsx
@@ -1,19 +1,13 @@
-import { useEffect } from 'react';
-
 import { DateBaseTimer } from '@/components';
-import useModal from '@/hooks/useModal';
 import useTimerStore from '@/store/TimerStore';
 import { MINUTES_IN_MS } from '@/utils/timer';
 
-import ProblemEndModal from '../ProblemEndModal/ProblemEndModal';
 import * as S from './ProblemTimer.style';
 interface TimerProps {
   isProblemSolvePage: boolean;
 }
 
 export default function ProblemTimer({ isProblemSolvePage }: TimerProps) {
-  const { modalRef, isOpen, openModal, closeModal } = useModal();
-
   const { isEnd, setIsEnd } = useTimerStore(state => state);
 
   // TODO: 서버 timestamp로 교체 필요, 1시간 기준으로 테스트 중
@@ -21,14 +15,6 @@ export default function ProblemTimer({ isProblemSolvePage }: TimerProps) {
   const endDateISOString = new Date(
     now.getTime() + 60 * MINUTES_IN_MS
   ).toISOString();
-
-  useEffect(() => {
-    if (isEnd) {
-      openModal();
-    } else {
-      closeModal();
-    }
-  }, [isEnd]);
 
   return (
     <S.Wrapper>
@@ -47,17 +33,6 @@ export default function ProblemTimer({ isProblemSolvePage }: TimerProps) {
           </>
         )}
       </S.TimeLeftWrapper>
-      {/* TODO: 삭제 예정 navigate 테스트용 코드 */}
-      {isProblemSolvePage && (
-        <S.TestButton onClick={() => openModal()}>
-          시험 종료 후 풀이 공유 페이지로 이동
-        </S.TestButton>
-      )}
-      <ProblemEndModal
-        modalRef={modalRef}
-        isOpen={isOpen}
-        closeModal={closeModal}
-      />
     </S.Wrapper>
   );
 }

--- a/src/pages/ProblemSolvePage/ProblemTimer/ProblemTimer.tsx
+++ b/src/pages/ProblemSolvePage/ProblemTimer/ProblemTimer.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { DateBaseTimer } from '@/components';
 import useModal from '@/hooks/useModal';
 import useTimerStore from '@/store/TimerStore';
@@ -12,7 +14,6 @@ interface TimerProps {
 export default function ProblemTimer({ isProblemSolvePage }: TimerProps) {
   const { modalRef, isOpen, openModal, closeModal } = useModal();
 
-  // TODO: 삭제 예정 navigate 테스트용 코드
   const { isEnd, setIsEnd } = useTimerStore(state => state);
 
   // TODO: 서버 timestamp로 교체 필요, 1시간 기준으로 테스트 중
@@ -20,6 +21,14 @@ export default function ProblemTimer({ isProblemSolvePage }: TimerProps) {
   const endDateISOString = new Date(
     now.getTime() + 60 * MINUTES_IN_MS
   ).toISOString();
+
+  useEffect(() => {
+    if (isEnd) {
+      openModal();
+    } else {
+      closeModal();
+    }
+  }, [isEnd]);
 
   return (
     <S.Wrapper>

--- a/src/pages/ProblemSolvePage/constants.ts
+++ b/src/pages/ProblemSolvePage/constants.ts
@@ -23,3 +23,10 @@ export const SIZE_PERCENTAGE = {
   EDITOR: 70,
   EXECUTION: 30,
 } as const;
+
+export const STATUS_DATA_SET: Record<string, string> = {
+  SUCCESS: '성공',
+  FAIL: '실패',
+  TIMEOUT: '시간 초과',
+  ERROR: '기타 에러',
+};

--- a/src/pages/ProblemSolvePage/constants.ts
+++ b/src/pages/ProblemSolvePage/constants.ts
@@ -28,5 +28,6 @@ export const STATUS_DATA_SET: Record<string, string> = {
   SUCCESS: '성공',
   FAIL: '실패',
   TIMEOUT: '시간 초과',
+  MEMORY: '메모리 초과',
   ERROR: '기타 에러',
 };

--- a/src/services/ProblemSolve/submission.ts
+++ b/src/services/ProblemSolve/submission.ts
@@ -6,6 +6,7 @@ interface SubmissionRequest {
   language: string;
   code: string;
   problemLink: string;
+  solveStatus: string;
 }
 
 export interface TestCaseResultType {


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->

API가 변경됨에 따라 페이지 레이아웃을 수정합니다.

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가

## 💻 작업 내용

<!-- PR 본문을 입력하세요. -->

- 백준 성공 여부를 입력하는 status 드롭다운을 추가합니다.
- 제출 모달의 테스트 케이스 섹션을 제거합니다.
- 공유 페이지 문구를 수정합니다.
- 문제 풀이 -> 문제 공유 페이지로 넘어가는 경우 replace true 속성을 주어 뒤로가기로 진입하는 것을 방지합니다.
- 타이머 종료에 따라서 시험 종료 모달을 띄워줍니다. (반영이 안되어있어서 추가했어유)

## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->

<img width="400" alt="스크린샷 2024-03-19 오후 3 44 55" src="https://github.com/1e5i-Shark/algobaro-fe/assets/55135881/d4884656-e77d-4c0e-8564-58ddba8d0457">
<img width="400" alt="스크린샷 2024-03-19 오후 3 45 12" src="https://github.com/1e5i-Shark/algobaro-fe/assets/55135881/34b6e5e0-39f4-4e24-bfae-4f8fbcba7e5c">

- 제가 임의로 socket을 설정해서 팀원이 문제를 풀고 있는 상황을 만들어봤는데 요부분은 소켓 연결되고 다같이 테스트해보면 좋을 것 같습니다!

<img width="293" alt="스크린샷 2024-03-19 오후 3 54 10" src="https://github.com/1e5i-Shark/algobaro-fe/assets/55135881/3f8078af-699b-44c6-a56b-85dfb88cacfe">


- **안내 문구와 드롭다운에 들어가는 내용이 괜찮은지 검토 부탁드립니다!!**
