### PR TITLE
[♻️refactor]: 아바타 isSelect 기능 추가

### DIFF
--- a/src/components/Common/Avatar/Avatar.style.ts
+++ b/src/components/Common/Avatar/Avatar.style.ts
@@ -5,7 +5,6 @@ import { Shape, Size } from '@/types';
 interface AvatarStyledProps {
   $size: Size;
   $shape: Shape;
-  $src?: string;
   $isSelect?: boolean;
   $isShadow: boolean;
   $isPointer?: boolean;
@@ -13,13 +12,14 @@ interface AvatarStyledProps {
 }
 
 export const AvatarWrapper = styled.div<AvatarStyledProps>`
-  ${({ theme, $size, $isSelect, $shape, $isShadow, $src }) => css`
+  ${({ theme, $size, $isSelect, $shape, $isShadow }) => css`
     position: relative;
     box-sizing: border-box;
     display: inline-block;
     width: ${theme.size.icon[$size]};
     height: ${theme.size.icon[$size]};
     overflow: hidden;
+    background-color: ${theme.color.background_primary};
     border: ${$isSelect
       ? `3px solid ${theme.color.primary_color}`
       : `1px solid ${theme.color.transparent_30}`};
@@ -28,21 +28,6 @@ export const AvatarWrapper = styled.div<AvatarStyledProps>`
     (theme.mode === 'light'
       ? `0px 4px 8px ${theme.color.black_primary}20`
       : `0px 4px 8px #00000050`)};
-    &::before {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      content: '';
-      background-color: ${theme.color.background_primary};
-      background-image: ${$src
-        ? `url(${$src}), url('/assets/avatar-${theme.mode}.png')`
-        : `url('/assets/avatar-${theme.mode}.png')`};
-      background-repeat: no-repeat;
-      background-position: center;
-      background-size: cover;
-    }
   `}
 `;
 
@@ -58,6 +43,6 @@ export const AvatarContainer = styled.div<
 
 export const EditButtonWrapper = styled.div`
   position: absolute;
-  right: -5px;
-  bottom: 0px;
+  right: -0.5rem;
+  bottom: 0;
 `;

--- a/src/components/Common/Avatar/Avatar.style.ts
+++ b/src/components/Common/Avatar/Avatar.style.ts
@@ -6,21 +6,23 @@ interface AvatarStyledProps {
   $size: Size;
   $shape: Shape;
   $src?: string;
-  $isBorder: boolean;
+  $isSelect?: boolean;
   $isShadow: boolean;
   $isPointer?: boolean;
   onClick?: (event: React.MouseEventHandler<HTMLElement>) => void;
 }
 
 export const AvatarWrapper = styled.div<AvatarStyledProps>`
-  ${({ theme, $size, $isBorder, $shape, $isShadow, $src }) => css`
+  ${({ theme, $size, $isSelect, $shape, $isShadow, $src }) => css`
     position: relative;
     box-sizing: border-box;
     display: inline-block;
     width: ${theme.size.icon[$size]};
     height: ${theme.size.icon[$size]};
     overflow: hidden;
-    border: ${$isBorder ? `1px solid ${theme.color.transparent_30}` : 'none'};
+    border: ${$isSelect
+      ? `3px solid ${theme.color.primary_color}`
+      : `1px solid ${theme.color.transparent_30}`};
     border-radius: ${theme.shape[$shape]};
     box-shadow: ${$isShadow &&
     (theme.mode === 'light'

--- a/src/components/Common/Avatar/Avatar.tsx
+++ b/src/components/Common/Avatar/Avatar.tsx
@@ -1,4 +1,7 @@
-import { Shape, Size } from '@/types';
+import { useEffect, useState } from 'react';
+
+import { useCustomTheme } from '@/hooks/useCustomTheme';
+import { Shape } from '@/types';
 
 import {
   AvatarContainer,
@@ -8,12 +11,14 @@ import {
 import EditButton from './EditButton';
 
 export interface AvatarProps {
-  size?: Size;
+  size?: 'XS' | 'S' | 'M' | 'L' | 'XL';
   shape?: Shape;
   src?: string;
+  alt?: string;
   isSelect?: boolean;
   isShadow?: boolean;
   isEdit?: boolean;
+  priority?: boolean;
   onClick?: (event: React.MouseEventHandler<HTMLElement>) => void;
 }
 
@@ -21,22 +26,38 @@ export interface AvatarProps {
  * @param [size='S'] - XS, S, M, L, XL
  * @param [shape='circle'] - circle은 원형, square는 사각형, round는 둥근 사각형
  * @param src - 이미지 소스
+ * [alt="avatar"] - 이미지 대체 텍스트
  * @param [isSelect=false] - true는 굵은 border 적용
  * @param [isShadow=true] - true는 그림자 적용
  * @param [isEdit=false] - true는 편집 아이콘 적용
+ * @param priority - 우선순위 true인 경우 lazy loading과 비동기 디코딩이 적용됩니다.
  * @param onClick - 마우스 클릭 핸들러 함수
  */
 export default function Avatar({
+  src,
   size = 'S',
   shape = 'circle',
-  src,
+  alt = 'avatar',
   isSelect = false,
   isShadow = true,
   isEdit = false,
+  priority = false,
   onClick,
   ...props
 }: AvatarProps) {
+  const { theme } = useCustomTheme();
+
+  const [source, setSource] = useState(src);
+
   const isPointer = onClick ? true : false;
+
+  useEffect(() => {
+    setSource(src || `/assets/avatar-${theme.mode}.png`);
+  }, [theme.mode]);
+
+  const handleError = () => {
+    setSource(`/assets/avatar-${theme.mode}.png`);
+  };
 
   return (
     <AvatarContainer
@@ -46,11 +67,23 @@ export default function Avatar({
       <AvatarWrapper
         $size={size}
         $shape={shape}
-        $src={src}
         $isSelect={isSelect}
         $isShadow={isShadow}
         {...props}
-      />
+      >
+        <img
+          src={source || `/assets/avatar-${theme.mode}.png`}
+          alt={alt}
+          width="100%"
+          height="100%"
+          loading={!priority ? 'lazy' : 'eager'}
+          decoding={!priority ? 'async' : 'auto'}
+          onError={handleError}
+          style={{
+            objectFit: 'cover',
+          }}
+        />
+      </AvatarWrapper>
       {isEdit && (
         <EditButtonWrapper>
           <EditButton />

--- a/src/components/Common/Avatar/Avatar.tsx
+++ b/src/components/Common/Avatar/Avatar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { useCustomTheme } from '@/hooks/useCustomTheme';
-import { Shape } from '@/types';
+import { Shape, Size } from '@/types';
 
 import {
   AvatarContainer,
@@ -11,7 +11,7 @@ import {
 import EditButton from './EditButton';
 
 export interface AvatarProps {
-  size?: 'XS' | 'S' | 'M' | 'L' | 'XL';
+  size?: Partial<Size>;
   shape?: Shape;
   src?: string;
   alt?: string;

--- a/src/components/Common/Avatar/Avatar.tsx
+++ b/src/components/Common/Avatar/Avatar.tsx
@@ -11,7 +11,7 @@ export interface AvatarProps {
   size?: Size;
   shape?: Shape;
   src?: string;
-  isBorder?: boolean;
+  isSelect?: boolean;
   isShadow?: boolean;
   isEdit?: boolean;
   onClick?: (event: React.MouseEventHandler<HTMLElement>) => void;
@@ -21,7 +21,7 @@ export interface AvatarProps {
  * @param [size='S'] - XS, S, M, L, XL
  * @param [shape='circle'] - circle은 원형, square는 사각형, round는 둥근 사각형
  * @param src - 이미지 소스
- * @param [isBorder=true] - true는 보더(solid) 적용
+ * @param [isSelect=false] - true는 굵은 border 적용
  * @param [isShadow=true] - true는 그림자 적용
  * @param [isEdit=false] - true는 편집 아이콘 적용
  * @param onClick - 마우스 클릭 핸들러 함수
@@ -30,7 +30,7 @@ export default function Avatar({
   size = 'S',
   shape = 'circle',
   src,
-  isBorder = true,
+  isSelect = false,
   isShadow = true,
   isEdit = false,
   onClick,
@@ -47,7 +47,7 @@ export default function Avatar({
         $size={size}
         $shape={shape}
         $src={src}
-        $isBorder={isBorder}
+        $isSelect={isSelect}
         $isShadow={isShadow}
         {...props}
       />

--- a/src/pages/ProblemSharePage/UserProfileList/UserProfileList.tsx
+++ b/src/pages/ProblemSharePage/UserProfileList/UserProfileList.tsx
@@ -29,6 +29,7 @@ export default function UserProfileList({
             <Avatar
               size="L"
               src={user.profileImage ?? ''}
+              isSelect={user.memberId === selectedUserId}
             />
             <S.UserName $isSelected={selectedUser?.memberId === user.memberId}>
               <EllipsisText


### PR DESCRIPTION
## 📝 설명
아바타 컴포넌트에 isSelect를 추가합니다.
isSelect는 특정 아바타를 선택했을 때 border 속성이 적용됩니다.
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/124686011/0e7d3a20-0099-49cf-9d13-377b11dbfab1)


## ✅ PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 💻 작업 내용
- [x] isSelect 기능을 추가했습니다.
- [x] isBorder 속성을 삭제하고 해당 css를 기본값으로 적용한다.
- [x] img 태그로 변경한다.
css에서 적용되던 background-image의 기능을 &lt;img&gt;로 변경했습니다. img는 onError를 핸들링 할 수 있습니다.

## 💬 PR 포인트
- 간단한 작업으로 별도로 이슈 생성하지 않고 브랜치를 생성했습니다.
- ProblemSolve에서 프로필에 적용해두었습니다. conflict 발생 시 isSelect를 적용해주세요.
- 배포 에러 확인 부탁드려요! npm run lint 수행 시 발생하는 에러는 없습니다.