### PR TITLE
[✨feat]: 테스트 케이스 입력 Input 구현 및 제출 모달에서 테스트 결과 표시 기능 다시 추가

### DIFF
--- a/src/hooks/useProblemSolve.ts
+++ b/src/hooks/useProblemSolve.ts
@@ -5,6 +5,7 @@ import { SOCKET_TYPE } from '@/constants/socket';
 import { PATH } from '@/routes/path';
 import { compile } from '@/services/ProblemSolve/compile';
 import { submission } from '@/services/ProblemSolve/submission';
+import { testCaseSubmission } from '@/services/ProblemSolve/testCaseSubmission';
 import useCodeEditorStore from '@/store/CodeEditorStore';
 import useMessageStore from '@/store/MessageStore';
 import useRoomStore from '@/store/RoomStore';
@@ -35,6 +36,22 @@ export const useSubmission = () => {
       // 코드 제출 성공 시 소켓 END_CODING 전송 -> 공유 페이지로 이동
       sendMessage(SOCKET_TYPE.ROOM.END_CODING);
       navigate(`${PATH.PROBLEMSHARE}/${roomShortUuid}`, { replace: true });
+    },
+  });
+};
+
+/**
+ * 백준 문제 링크의 테스트 케이스에 대한 코드 결과를 가져오는 useMutation 훅
+ * @returns 테스트 결과 배열 객체
+ */
+export const useTestCaseSubmission = () => {
+  return useMutation({
+    mutationFn: testCaseSubmission,
+    onSuccess: data => {
+      if (data.response.testCaseResults) {
+        return data.response.testCaseResults;
+      }
+      return data;
     },
   });
 };

--- a/src/pages/ProblemSolvePage/ProblemSolvePage.style.ts
+++ b/src/pages/ProblemSolvePage/ProblemSolvePage.style.ts
@@ -16,6 +16,7 @@ const ProblemLinkContainer = styled.div`
   ${({ theme }) => css`
     display: flex;
     justify-content: end;
+    min-width: 40rem;
     height: ${theme.size.XXL};
     padding: 0.5rem;
     background-color: ${theme.color.background_editor};

--- a/src/pages/ProblemSolvePage/ProblemSolvePage.style.ts
+++ b/src/pages/ProblemSolvePage/ProblemSolvePage.style.ts
@@ -42,6 +42,11 @@ const EditorWrapper = styled(Col)`
   height: 100%;
 `;
 
+const ExecutionWrapper = styled(Row)`
+  width: 100%;
+  height: 100%;
+`;
+
 const ButtonWrapper = styled(Row)`
   ${({ theme }) => css`
     gap: 1.2rem;
@@ -57,6 +62,7 @@ export {
   ButtonWrapper,
   ContentsWrapper,
   EditorWrapper,
+  ExecutionWrapper,
   ProblemLink,
   ProblemLinkContainer,
   ProblemLinkText,

--- a/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
@@ -16,6 +16,7 @@ import ProblemExecution from './ProblemExecution/ProblemExecution';
 import ProblemSection from './ProblemSection/ProblemSection';
 import * as S from './ProblemSolvePage.style';
 import ProblemSubmitModal from './ProblemSubmitModal/ProblemSubmitModal';
+import TestCaseInput from './TestCaseInput/TestCaseInput';
 
 export default function ProblemSolvePage() {
   const { theme } = useCustomTheme();
@@ -33,7 +34,9 @@ export default function ProblemSolvePage() {
   } = useCompile();
   const { data: roomDetail, refetch } = useGetUuidRoom(roomShortUuid);
 
-  const { input, code, language, reset } = useCodeEditorStore(state => state);
+  const { input, code, language, reset, setInput } = useCodeEditorStore(
+    state => state
+  );
   const {
     roomData: { problemLink },
     setRoomData,
@@ -47,12 +50,18 @@ export default function ProblemSolvePage() {
   };
 
   const handleCompileExecution = async () => {
-    if (confirm('하루 실행 제한이 있습니다. 정말 실행하시겠습니까?'))
+    if (confirm('하루 실행 제한이 있습니다. 정말 실행하시겠습니까?')) {
+      console.log({ code, input, language });
       compileMutate({ code, input, language });
+    }
   };
 
   const handleSubmit = async () => {
     openModal();
+  };
+
+  const handleChangeTestCase = (newText: string) => {
+    setInput(newText);
   };
 
   useEffect(() => {
@@ -102,10 +111,13 @@ export default function ProblemSolvePage() {
               <ResizeHandle direction={DIRECTION.VERTICAL} />
               <Panel defaultSize={SIZE_PERCENTAGE.EXECUTION}>
                 {/* 실행 영역 */}
-                <ProblemExecution
-                  isLoading={isCompileLoading}
-                  isError={isCompileError}
-                />
+                <S.ExecutionWrapper>
+                  <TestCaseInput onChange={handleChangeTestCase} />
+                  <ProblemExecution
+                    isLoading={isCompileLoading}
+                    isError={isCompileError}
+                  />
+                </S.ExecutionWrapper>
               </Panel>
             </PanelGroup>
           </Panel>

--- a/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
@@ -51,7 +51,6 @@ export default function ProblemSolvePage() {
 
   const handleCompileExecution = async () => {
     if (confirm('하루 실행 제한이 있습니다. 정말 실행하시겠습니까?')) {
-      console.log({ code, input, language });
       compileMutate({ code, input, language });
     }
   };
@@ -110,14 +109,23 @@ export default function ProblemSolvePage() {
               </Panel>
               <ResizeHandle direction={DIRECTION.VERTICAL} />
               <Panel defaultSize={SIZE_PERCENTAGE.EXECUTION}>
+                <PanelGroup direction={DIRECTION.HORIZONTAL}>
+                  <Panel defaultSize={SIZE_PERCENTAGE.EXECUTION_INPUT}>
+                    <S.ExecutionWrapper>
+                      <TestCaseInput onChange={handleChangeTestCase} />
+                    </S.ExecutionWrapper>
+                  </Panel>
+                  <ResizeHandle direction={DIRECTION.HORIZONTAL} />
+                  <Panel defaultSize={SIZE_PERCENTAGE.EXECUTION_RESULT}>
+                    <S.ExecutionWrapper>
+                      <ProblemExecution
+                        isLoading={isCompileLoading}
+                        isError={isCompileError}
+                      />
+                    </S.ExecutionWrapper>
+                  </Panel>
+                </PanelGroup>
                 {/* 실행 영역 */}
-                <S.ExecutionWrapper>
-                  <TestCaseInput onChange={handleChangeTestCase} />
-                  <ProblemExecution
-                    isLoading={isCompileLoading}
-                    isError={isCompileError}
-                  />
-                </S.ExecutionWrapper>
               </Panel>
             </PanelGroup>
           </Panel>

--- a/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.style.ts
+++ b/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.style.ts
@@ -17,8 +17,57 @@ const Title = styled.p`
   `};
 `;
 
-const BOJWrapper = styled.div`
+const SubmissionWrapper = styled(Col)``;
+
+const SubmissionLayoutContainer = styled(Row)`
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+`;
+
+const TestCaseResultWrapper = styled.div``;
+
+const BojSubmissionWrapper = styled(Col)``;
+
+const ResultShareWrapper = styled.div`
   white-space: pre-line;
+`;
+
+const TestResultWrapper = styled.div`
+  height: 4rem;
+  text-align: center;
+  white-space: pre-line;
+`;
+
+const TestErrorText = styled.span`
+  ${({ theme }) => css`
+    line-height: ${theme.size.XXL};
+    color: ${theme.color.red};
+  `};
+`;
+
+const TestCaseList = styled.ul`
+  display: flex;
+  flex-direction: column;
+`;
+
+const TestCaseItem = styled.li`
+  display: flex;
+  align-items: center;
+  height: 3rem;
+`;
+
+const LottieWrapper = styled(Row)`
+  justify-content: center;
+  width: 5rem;
+`;
+
+const TestCaseTitle = styled.p`
+  ${({ theme }) => css`
+    width: 8rem;
+    font-size: 1.6rem;
+    font-weight: ${theme.fontWeight.medium};
+  `};
 `;
 
 const BOJGuideText = styled.p`
@@ -27,6 +76,7 @@ const BOJGuideText = styled.p`
     line-height: ${theme.size.XXL};
     color: ${theme.color.text_primary_color};
     text-align: center;
+    white-space: pre-wrap;
   `};
 `;
 
@@ -47,8 +97,18 @@ const EndButtonWrapper = styled(Row)`
 export {
   BOJButtonWrapper,
   BOJGuideText,
-  BOJWrapper,
+  BojSubmissionWrapper,
   EndButtonWrapper,
+  LottieWrapper,
+  ResultShareWrapper,
+  SubmissionLayoutContainer,
+  SubmissionWrapper,
+  TestCaseItem,
+  TestCaseList,
+  TestCaseResultWrapper,
+  TestCaseTitle,
+  TestErrorText,
+  TestResultWrapper,
   Title,
   Wrapper,
 };

--- a/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSubmitModal/ProblemSubmitModal.tsx
@@ -1,15 +1,19 @@
 import { useEffect, useState } from 'react';
+import Lottie from 'react-lottie';
 import { useNavigate } from 'react-router-dom';
 
-import { Button, DropDown, Modal } from '@/components';
+import { Button, DropDown, Modal, Spinner } from '@/components';
 import { useCustomTheme } from '@/hooks/useCustomTheme';
-import { useSubmission } from '@/hooks/useProblemSolve';
+import { useSubmission, useTestCaseSubmission } from '@/hooks/useProblemSolve';
 import { PATH } from '@/routes/path';
+import { TestCaseResultType } from '@/services/ProblemSolve/submission';
 import useCodeEditorStore from '@/store/CodeEditorStore';
 import useRoomStore from '@/store/RoomStore';
 import useTimerStore from '@/store/TimerStore';
 
 import { STATUS_DATA_SET } from '../constants';
+import failLottie from './lottie/fail-lottie.json';
+import successLottie from './lottie/success-lottie.json';
 import * as S from './ProblemSubmitModal.style';
 
 interface ProblemSubmitModalProps {
@@ -32,8 +36,13 @@ export default function ProblemSubmitModal({
   const [isSubmitDisabled, setIsSubmitDisabled] = useState(true);
   const [solveStatus, setSolveStatus] = useState('SUCCESS');
   const [failureReason, setFailureReason] = useState('');
+  const [testCaseResult, setTestCaseResult] = useState<TestCaseResultType[]>(
+    []
+  );
 
   const { mutateAsync: submitMutateAsync } = useSubmission();
+  const { mutateAsync: testCaseSubmitMutateAsync, isLoading } =
+    useTestCaseSubmission();
 
   const navigate = useNavigate();
 
@@ -70,9 +79,27 @@ export default function ProblemSubmitModal({
     navigate(`${PATH.PROBLEMSHARE}/${roomShortUuid}`, { replace: true });
   };
 
+  const handleSubmit = async () => {
+    const result = await testCaseSubmitMutateAsync({
+      roomShortUuid,
+      language,
+      code,
+      problemLink,
+      solveStatus,
+      failureReason,
+    });
+
+    if (result.response?.testCaseResults) {
+      setTestCaseResult(result.response.testCaseResults);
+    }
+  };
+
   useEffect(() => {
     if (isOpen) {
+      handleSubmit();
       setIsSubmitDisabled(true);
+    } else {
+      setTestCaseResult([]);
     }
   }, [isOpen]);
 
@@ -86,19 +113,59 @@ export default function ProblemSubmitModal({
       onClose={closeModal}
     >
       <S.Wrapper>
-        <S.BOJWrapper>
+        <S.SubmissionWrapper>
           <S.Title>제출하기</S.Title>
-          <S.BOJGuideText>{`백준 사이트에 제출하여 채점 결과를 확인해 보세요!`}</S.BOJGuideText>
-          <S.BOJButtonWrapper>
-            <Button
-              width="16rem"
-              height="5rem"
-              fontSize="1.6rem"
-              onClick={handleBOJSubmit}
-            >
-              백준 제출하러 가기
-            </Button>
-          </S.BOJButtonWrapper>
+          <S.SubmissionLayoutContainer>
+            <S.TestCaseResultWrapper>
+              {testCaseResult.length === 0 && (
+                <S.TestResultWrapper>
+                  {isLoading ? (
+                    <Spinner />
+                  ) : (
+                    <S.TestErrorText>{`실행 중 오류가 발생했습니다 \n 잠시 후 다시 시도해주세요`}</S.TestErrorText>
+                  )}
+                </S.TestResultWrapper>
+              )}
+              {testCaseResult.length > 0 && (
+                <S.TestCaseList>
+                  {testCaseResult.map((result, index) => (
+                    <S.TestCaseItem key={index}>
+                      <S.TestCaseTitle>{`TestCase ${index + 1}:`}</S.TestCaseTitle>
+                      <S.LottieWrapper>
+                        <Lottie
+                          width={result.success ? 100 : 21}
+                          height={result.success ? 100 : 21}
+                          options={{
+                            loop: false,
+                            autoplay: true,
+                            animationData: result.success
+                              ? successLottie
+                              : failLottie,
+                          }}
+                          style={{ margin: '0' }}
+                        />
+                      </S.LottieWrapper>
+                    </S.TestCaseItem>
+                  ))}
+                </S.TestCaseList>
+              )}
+            </S.TestCaseResultWrapper>
+            <S.BojSubmissionWrapper>
+              <S.BOJGuideText>{`백준 사이트에 제출하여 \n 채점 결과를 확인해 보세요!`}</S.BOJGuideText>
+              <S.BOJButtonWrapper>
+                <Button
+                  width="16rem"
+                  height="5rem"
+                  fontSize="1.6rem"
+                  onClick={handleBOJSubmit}
+                >
+                  백준 제출하러 가기
+                </Button>
+              </S.BOJButtonWrapper>
+            </S.BojSubmissionWrapper>
+          </S.SubmissionLayoutContainer>
+        </S.SubmissionWrapper>
+        <S.ResultShareWrapper>
           <S.Title>결과 공유하기</S.Title>
           <S.BOJGuideText>{`팀원들에게 채점 결과를 공유해 주세요 🤗`}</S.BOJGuideText>
           <S.BOJButtonWrapper>
@@ -137,7 +204,7 @@ export default function ProblemSubmitModal({
               풀이 종료하기
             </Button>
           </S.EndButtonWrapper>
-        </S.BOJWrapper>
+        </S.ResultShareWrapper>
       </S.Wrapper>
     </Modal>
   );

--- a/src/pages/ProblemSolvePage/TestCaseInput/TestCaseInput.style.ts
+++ b/src/pages/ProblemSolvePage/TestCaseInput/TestCaseInput.style.ts
@@ -35,6 +35,7 @@ const TestInputWrapper = styled(Col)`
 const TestInput = styled.textarea`
   ${({ theme }) => css`
     height: 2.2rem;
+    padding: 0 ${theme.size.L};
     overflow: auto;
     font: inherit;
     color: ${theme.color.black_primary};

--- a/src/pages/ProblemSolvePage/TestCaseInput/TestCaseInput.style.ts
+++ b/src/pages/ProblemSolvePage/TestCaseInput/TestCaseInput.style.ts
@@ -1,0 +1,52 @@
+import styled, { css } from 'styled-components';
+
+import { Col } from '@/styles/GlobalStyle';
+
+const Wrapper = styled(Col)`
+  ${({ theme }) => css`
+    width: 100%;
+    height: 100%;
+    padding: 1.6rem 2rem;
+    background-color: ${theme.color.background_editor};
+  `}
+`;
+
+const TestCaseTitle = styled.span`
+  ${({ theme }) => css`
+    font-weight: ${theme.fontWeight.bold};
+  `}
+`;
+
+const TestInputWrapper = styled(Col)`
+  ${({ theme }) => css`
+    justify-content: center;
+    height: 100%;
+    padding: 0.4rem 1rem;
+    margin-top: 1rem;
+    overflow: auto;
+    color: ${theme.color.black_primary};
+    white-space: pre-line;
+    background-color: ${theme.color.gray_10};
+    border: 0.1rem solid ${theme.color.gray_30};
+    border-radius: ${theme.shape.round};
+  `}
+`;
+
+const TestInput = styled.textarea`
+  ${({ theme }) => css`
+    height: 2.2rem;
+    overflow: auto;
+    font: inherit;
+    color: ${theme.color.black_primary};
+    white-space: pre-line;
+    vertical-align: middle;
+    background-color: ${theme.color.gray_10};
+
+    &::placeholder {
+      font-size: 1.6rem;
+      color: ${theme.color.gray_50};
+    }
+  `}
+`;
+
+export { TestCaseTitle, TestInput, TestInputWrapper, Wrapper };

--- a/src/pages/ProblemSolvePage/TestCaseInput/TestCaseInput.style.ts
+++ b/src/pages/ProblemSolvePage/TestCaseInput/TestCaseInput.style.ts
@@ -46,6 +46,7 @@ const TestInput = styled.textarea`
     &::placeholder {
       font-size: 1.6rem;
       color: ${theme.color.gray_50};
+      text-align: center;
     }
   `}
 `;

--- a/src/pages/ProblemSolvePage/TestCaseInput/TestCaseInput.tsx
+++ b/src/pages/ProblemSolvePage/TestCaseInput/TestCaseInput.tsx
@@ -1,0 +1,35 @@
+import { ChangeEvent, useRef } from 'react';
+
+import * as S from './TestCaseInput.style';
+
+interface TestCaseInputProps {
+  onChange: (newText: string) => void;
+}
+
+export default function TestCaseInput({ onChange }: TestCaseInputProps) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const handleResizeTextarea = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    const newText = e.currentTarget.value;
+    onChange(newText);
+    // textarea 높이 조절
+    if (textareaRef && textareaRef.current) {
+      textareaRef.current.style.height = '1rem';
+      textareaRef.current.style.height =
+        textareaRef.current.scrollHeight + 'px';
+    }
+  };
+
+  return (
+    <S.Wrapper>
+      <S.TestCaseTitle>테스트 입력</S.TestCaseTitle>
+      <S.TestInputWrapper>
+        <S.TestInput
+          ref={textareaRef}
+          onChange={handleResizeTextarea}
+          placeholder="테스트 케이스를 입력하세요."
+        />
+      </S.TestInputWrapper>
+    </S.Wrapper>
+  );
+}

--- a/src/pages/ProblemSolvePage/TestCaseInput/TestCaseInput.tsx
+++ b/src/pages/ProblemSolvePage/TestCaseInput/TestCaseInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useRef } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
 
 import * as S from './TestCaseInput.style';
 
@@ -8,6 +8,8 @@ interface TestCaseInputProps {
 
 export default function TestCaseInput({ onChange }: TestCaseInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const [isFocus, setIsFocus] = useState(false);
 
   const handleResizeTextarea = (e: ChangeEvent<HTMLTextAreaElement>) => {
     const newText = e.currentTarget.value;
@@ -20,6 +22,14 @@ export default function TestCaseInput({ onChange }: TestCaseInputProps) {
     }
   };
 
+  const handleFocusInput = () => {
+    setIsFocus(true);
+  };
+
+  const handleBlurInput = () => {
+    setIsFocus(false);
+  };
+
   return (
     <S.Wrapper>
       <S.TestCaseTitle>테스트 입력</S.TestCaseTitle>
@@ -27,7 +37,9 @@ export default function TestCaseInput({ onChange }: TestCaseInputProps) {
         <S.TestInput
           ref={textareaRef}
           onChange={handleResizeTextarea}
-          placeholder="테스트 케이스를 입력하세요."
+          onFocus={handleFocusInput}
+          onBlur={handleBlurInput}
+          placeholder={!isFocus ? '테스트 케이스를 입력하세요.' : ''}
         />
       </S.TestInputWrapper>
     </S.Wrapper>

--- a/src/pages/ProblemSolvePage/constants.ts
+++ b/src/pages/ProblemSolvePage/constants.ts
@@ -22,6 +22,8 @@ export const SIZE_PERCENTAGE = {
   SOLVE: 60,
   EDITOR: 70,
   EXECUTION: 30,
+  EXECUTION_INPUT: 40,
+  EXECUTION_RESULT: 60,
 } as const;
 
 export const STATUS_DATA_SET: Record<string, string> = {

--- a/src/services/ProblemSolve/testCaseSubmission.ts
+++ b/src/services/ProblemSolve/testCaseSubmission.ts
@@ -1,0 +1,33 @@
+import { API_ENDPOINT } from '../apiEndpoint';
+import { axiosAuthInstance } from '../axiosInstance';
+import { TestCaseResultType } from './submission';
+
+interface TestCaseSubmissionRequest {
+  roomShortUuid: string;
+  language: string;
+  code: string;
+  problemLink: string;
+  solveStatus: string;
+  failureReason: string;
+}
+
+interface TestCaseSubmissionResponse {
+  success: boolean;
+  response: {
+    testCaseResults: TestCaseResultType[];
+  };
+}
+
+/**
+ * 백준 문제 링크에서 입력한 코드에 대한 테스트 케이스 결과를 가져오는 함수
+ * @param request TestCaseSubmissionRequest
+ * @returns 테스트 결과
+ */
+export const testCaseSubmission = async (
+  request: TestCaseSubmissionRequest
+) => {
+  return await axiosAuthInstance.post<TestCaseSubmissionResponse>(
+    `${API_ENDPOINT.SOVLE.TEST_CASE_SUBMISSION}`,
+    request
+  );
+};

--- a/src/services/apiEndpoint.ts
+++ b/src/services/apiEndpoint.ts
@@ -18,6 +18,7 @@ export const API_ENDPOINT = {
   },
   SOVLE: {
     RESULT: '/v1/solves/result',
+    TEST_CASE_SUBMISSION: '/v1/solves/submission-and-compile',
   },
 };
 export const EDIT_MY_INFO_URL = '/v1/members/my/general';

--- a/src/store/CodeEditorStore/index.ts
+++ b/src/store/CodeEditorStore/index.ts
@@ -15,14 +15,11 @@ interface Props {
   reset: () => void;
 }
 
-// TODO: 서버로부터 데이터 받아와서 교체 필요
-const MOCK_INPUT = '1 2';
-
 const useCodeEditorStore = create<Props>()(
   devtools(set => ({
     code: codeEditorDefaultValue['nodejs'],
     language: 'nodejs',
-    input: MOCK_INPUT,
+    input: '',
     result: '',
     setCode: (code: string) => set({ code }),
     setInput: (input: string) => set({ input }),
@@ -32,7 +29,7 @@ const useCodeEditorStore = create<Props>()(
       set({
         code: codeEditorDefaultValue['nodejs'],
         language: 'nodejs',
-        input: MOCK_INPUT,
+        input: '',
         result: '',
       });
     },


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->
사용자가 테스트 케이스를 입력하는 Input 컴포넌트를 추가하고 제출 모달에 테스트 결과 표시 기능을 다시 추가했습니다.

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 💻 작업 내용

<!-- PR 본문을 입력하세요. -->
### 테스트 결과 레이아웃
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/b8661f1d-9aad-44d2-9a3a-62848d282381)

#### 테스트 데이터
기존 `testCaseResult` state 값 대신 이것을 대체하면 위 사진처럼 나옵니다.
jdoodle 라이브러리 사용을 최소화하여 체크해주시면 되겠습니다.
```tsx
const testCaseResult = [
    {
      caseNumber: 1,
      input: '1 2',
      output: '3',
      result: '3',
      success: true,
    },
    {
      caseNumber: 2,
      input: '1 2',
      output: '3',
      result: '3',
      success: false,
    },
    {
      caseNumber: 3,
      input: '1 2',
      output: '3',
      result: '3',
      success: true,
    },
    {
      caseNumber: 4,
      input: '1 2',
      output: '3',
      result: '3',
      success: true,
    },
];
```

### 핵심 구현 및 변경사항
- 사용자가 테스트 케이스를 입력할 수 있도록 Input 영역을 추가했습니다.
  - placeholder 는 중앙 정렬했고 input이 포커싱되면 사라지고 왼쪽 정렬로 바뀌도록 구현했습니다.
  - Resize가 가능하도록 하여 테스트 케이스 입력 영역과 실행 결과 창의 크기를 조절할 수 있도록 했습니다.
 
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/726ae913-63bc-484a-a416-17aced117794)

- 제출 모달에서 테스트 케이스에 대한 결과를 표시하는 기능을 다시 추가했습니다. @pySoo 
  - 사용자는 테스트 결과를 확인 후 백준 사이트에서 최종 제출을 할 수 있도록 가로 배치했습니다.
  
![image](https://github.com/1e5i-Shark/algobaro-fe/assets/70748442/c22fd230-09f1-4731-bda8-89e7d13ed32f)



## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
- 테스트 케이스 입력 창으로 입력받은 데이터가 잘 적용되는지 테스트 부탁드립니다.
- 문제에 따라 테스트 케이스가 잘 적용되어 채점되는지 테스트 부탁드립니다.
