### PR TITLE
[🐛fix]: RoomPage QA 피드백 적용

### DIFF
--- a/src/components/Common/Chat/Chat.style.ts
+++ b/src/components/Common/Chat/Chat.style.ts
@@ -20,7 +20,6 @@ export const MessagesContainer = styled(Col)`
 
 export const MessageWrapper = styled.div`
   ${({ theme }) => css`
-    min-height: 9rem;
     border-top: ${`1px solid ${theme.color.transparent_50}`};
   `}
 `;

--- a/src/components/Common/Chat/Chat.style.ts
+++ b/src/components/Common/Chat/Chat.style.ts
@@ -20,6 +20,7 @@ export const MessagesContainer = styled(Col)`
 
 export const MessageWrapper = styled.div`
   ${({ theme }) => css`
+    min-height: 9rem;
     border-top: ${`1px solid ${theme.color.transparent_50}`};
   `}
 `;

--- a/src/components/Common/Chat/Chat.tsx
+++ b/src/components/Common/Chat/Chat.tsx
@@ -30,6 +30,11 @@ export default function Chat({ height = '100%' }: ChatProps) {
     return data?.nickname;
   };
 
+  const memberIdToAvatar = (memberId: number) => {
+    const data = roomMembers.find(member => member.memberId === memberId);
+    return data?.profileImage;
+  };
+
   useEffect(() => {
     scrollToBottom();
   }, [messageLogs]);
@@ -44,6 +49,7 @@ export default function Chat({ height = '100%' }: ChatProps) {
           return (
             <S.MessageWrapper key={v4()}>
               <Message
+                avatarSrc={memberIdToAvatar(message.memberId) || ''}
                 userName={memberIdToNickname(message.memberId) || ''}
                 comment={message.value || ''}
                 createdAt={message.timestamp}

--- a/src/components/Common/Chat/Chat.tsx
+++ b/src/components/Common/Chat/Chat.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { v4 } from 'uuid';
 
 import { Message } from '@/components';
+import { SOCKET_TYPE } from '@/constants/socket';
 import useMessageStore from '@/store/MessageStore';
 import useRoomStore from '@/store/RoomStore';
 
@@ -14,7 +15,9 @@ interface ChatProps {
 
 export default function Chat({ height = '100%' }: ChatProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+
   const { messageLogs } = useMessageStore();
+
   const {
     roomData: { roomMembers },
   } = useRoomStore();
@@ -25,14 +28,15 @@ export default function Chat({ height = '100%' }: ChatProps) {
     }
   };
 
-  const memberIdToNickname = (memberId: number) => {
+  const memberIdToData = (memberId: number) => {
     const data = roomMembers.find(member => member.memberId === memberId);
-    return data?.nickname;
-  };
 
-  const memberIdToAvatar = (memberId: number) => {
-    const data = roomMembers.find(member => member.memberId === memberId);
-    return data?.profileImage;
+    const result = {
+      profileImage: data?.profileImage || '',
+      nickname: data?.nickname || '',
+    };
+
+    return result;
   };
 
   useEffect(() => {
@@ -46,11 +50,16 @@ export default function Chat({ height = '100%' }: ChatProps) {
         className="message-container"
       >
         {messageLogs.map(message => {
+          const memberData = memberIdToData(message.memberId);
+          // 입장, 퇴장 시 system 메세지를 출력한다.
+          const isSystem =
+            message.type === SOCKET_TYPE.CHAT.ENTER ||
+            message.type === SOCKET_TYPE.CHAT.QUIT;
           return (
             <S.MessageWrapper key={v4()}>
               <Message
-                avatarSrc={memberIdToAvatar(message.memberId) || ''}
-                userName={memberIdToNickname(message.memberId) || ''}
+                avatarSrc={!isSystem ? memberData.profileImage : ''}
+                userName={!isSystem ? memberData.nickname : 'Algobaro'}
                 comment={message.value || ''}
                 createdAt={message.timestamp}
               />

--- a/src/components/Common/Chat/Chat.tsx
+++ b/src/components/Common/Chat/Chat.tsx
@@ -54,6 +54,9 @@ export default function Chat({ height = '100%' }: ChatProps) {
 
   useEffect(() => {
     scrollToBottom();
+  }, [messageList]);
+
+  useEffect(() => {
     if (messageLogs.length < 1) return;
 
     const newMessage = messageLogs.at(-1);

--- a/src/components/Common/Chat/Chat.tsx
+++ b/src/components/Common/Chat/Chat.tsx
@@ -58,7 +58,7 @@ export default function Chat({ height = '100%' }: ChatProps) {
           return (
             <S.MessageWrapper key={v4()}>
               <Message
-                avatarSrc={!isSystem ? memberData.profileImage : ''}
+                avatarSrc={!isSystem ? memberData.profileImage : 'system'}
                 userName={!isSystem ? memberData.nickname : 'Algobaro'}
                 comment={message.value || ''}
                 createdAt={message.timestamp}

--- a/src/components/Common/Chat/Chat.tsx
+++ b/src/components/Common/Chat/Chat.tsx
@@ -28,7 +28,7 @@ export default function Chat({ height = '100%' }: ChatProps) {
     roomData: { roomMembers },
   } = useRoomStore();
 
-  const [memberList, setMemberList] = useState<MessageState[]>([]);
+  const [messageList, setMessageList] = useState<MessageState[]>([]);
 
   const scrollToBottom = () => {
     if (scrollRef.current) {
@@ -49,7 +49,7 @@ export default function Chat({ height = '100%' }: ChatProps) {
       nickname: memberData?.nickname || '',
     };
 
-    return [...memberList, result as MessageState];
+    return [...messageList, result as MessageState];
   };
 
   useEffect(() => {
@@ -58,7 +58,7 @@ export default function Chat({ height = '100%' }: ChatProps) {
 
     const newMessage = messageLogs.at(-1);
     const newLogs = newMessage && memberIdToData(newMessage.memberId);
-    newLogs && setMemberList(newLogs);
+    newLogs && setMessageList(newLogs);
   }, [messageLogs, receiveLogs]);
 
   return (
@@ -67,10 +67,11 @@ export default function Chat({ height = '100%' }: ChatProps) {
         ref={scrollRef}
         className="message-container"
       >
-        {memberList.map(message => {
+        {messageList.map(message => {
           const isSystem =
             message.type === SOCKET_TYPE.CHAT.ENTER ||
             message.type === SOCKET_TYPE.CHAT.QUIT;
+
           return (
             <S.MessageWrapper key={v4()}>
               <Message

--- a/src/components/Common/Header/PSHeader.tsx
+++ b/src/components/Common/Header/PSHeader.tsx
@@ -1,6 +1,5 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { SOCKET_TYPE } from '@/constants/socket';
 import { useCustomTheme } from '@/hooks/useCustomTheme';
 import useModal from '@/hooks/useModal';
 import ProblemTimer from '@/pages/ProblemSolvePage/ProblemTimer/ProblemTimer';
@@ -20,7 +19,7 @@ export default function PSHeader() {
   const location = useLocation();
   const { reset: resetRoom } = useRoomStore();
 
-  const { connected, sendMessage, disconnect } = useMessageStore();
+  const { connected, disconnect } = useMessageStore();
 
   const isProblemSolvePage =
     location.pathname.split('/')[1] === PATH.PROBLEMSOLVE.replace('/', '');
@@ -34,7 +33,6 @@ export default function PSHeader() {
   const handleNavigateToHome = () => {
     // 홈으로 나가면 CheckRoute에 의해 소켓 연결 disconnect
     if (connected) {
-      sendMessage(SOCKET_TYPE.CHAT.QUIT);
       disconnect();
     }
 

--- a/src/components/Common/Message/Message.tsx
+++ b/src/components/Common/Message/Message.tsx
@@ -63,7 +63,7 @@ export default function Message({
         {...props}
       >
         <MessageSender $fontSize={fontSize}>
-          {avatarSrc && (
+          {avatarSrc !== 'system' && (
             <Avatar
               size={avatarSize}
               src={avatarSrc}

--- a/src/components/Common/Message/Message.tsx
+++ b/src/components/Common/Message/Message.tsx
@@ -45,7 +45,7 @@ export default function Message({
   avatarSize = 'XS',
   avatarSrc = '',
   avatarShadow = true,
-  userName = 'User1',
+  userName = 'Algobaro',
   fontSize = '1.6rem',
   iconSize = 'XS',
   comment,
@@ -63,11 +63,13 @@ export default function Message({
         {...props}
       >
         <MessageSender $fontSize={fontSize}>
-          <Avatar
-            size={avatarSize}
-            src={avatarSrc}
-            isShadow={avatarShadow}
-          />
+          {avatarSrc && (
+            <Avatar
+              size={avatarSize}
+              src={avatarSrc}
+              isShadow={avatarShadow}
+            />
+          )}
           <UserName>{userName}</UserName>
           <span
             style={{

--- a/src/hooks/Api/useRooms.ts
+++ b/src/hooks/Api/useRooms.ts
@@ -48,6 +48,7 @@ export const useGetUuidRoom = (roomShortUuid: string) => {
     queryKey: [QUERY_KEY.ROOM.UUID_INFO, roomShortUuid],
     queryFn: async () => await getUuidRoom(`/${roomShortUuid}`),
     enabled: !!roomShortUuid,
+    refetchInterval: 2000,
   });
 };
 

--- a/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
+++ b/src/pages/ProblemSolvePage/ProblemSolvePage.tsx
@@ -8,6 +8,7 @@ import { useCustomTheme } from '@/hooks/useCustomTheme';
 import useModal from '@/hooks/useModal';
 import { useCompile } from '@/hooks/useProblemSolve';
 import useCodeEditorStore from '@/store/CodeEditorStore';
+import useMessageStore from '@/store/MessageStore';
 import useRoomStore from '@/store/RoomStore';
 import useTimerStore from '@/store/TimerStore';
 
@@ -20,6 +21,13 @@ import ProblemSubmitModal from './ProblemSubmitModal/ProblemSubmitModal';
 export default function ProblemSolvePage() {
   const { theme } = useCustomTheme();
   const { modalRef, isOpen, openModal, closeModal } = useModal();
+
+  const {
+    client,
+    subscription,
+    connect,
+    reset: resetMessage,
+  } = useMessageStore();
 
   const params = useParams();
   const { roomShortUuid } = params;
@@ -72,6 +80,20 @@ export default function ProblemSolvePage() {
   useEffect(() => {
     reset();
     refetch();
+  }, []);
+
+  // 새로고침 해도 소켓 재접속
+  useEffect(() => {
+    connect(roomShortUuid);
+
+    return () => {
+      if (!client || !subscription) return;
+
+      subscription.unsubscribe();
+      client.deactivate();
+
+      resetMessage();
+    };
   }, []);
 
   return (

--- a/src/pages/RoomPage/RoomHeader/RoomHeader.tsx
+++ b/src/pages/RoomPage/RoomHeader/RoomHeader.tsx
@@ -3,7 +3,7 @@ import useModal from '@/hooks/useModal';
 import * as S from '@/pages/RoomPage/RoomPage.style';
 import useRoomStore from '@/store/RoomStore';
 
-import { ModalRoom, RoomHeaderButtons, RoomHeaderInfo } from '.';
+import { RoomHeaderButtons, RoomHeaderInfo, RoomUpdateModal } from '.';
 
 interface HeaderProps {
   className: string;
@@ -33,7 +33,7 @@ export default function RoomHeader({ className }: HeaderProps) {
         onClose={closeModal}
         ref={modalRef}
       >
-        <ModalRoom onClose={closeModal} />
+        <RoomUpdateModal onClose={closeModal} />
       </Modal>
     </>
   );

--- a/src/pages/RoomPage/RoomHeader/RoomHeaderInfo.tsx
+++ b/src/pages/RoomPage/RoomHeader/RoomHeaderInfo.tsx
@@ -14,13 +14,13 @@ interface RoomInfoProps {
 export default function RoomInfoContainer({ className }: RoomInfoProps) {
   const { theme } = useCustomTheme();
   const { roomData } = useRoomStore();
-  const { roomShortUuid, title, tags, languages, roomAccessType } = roomData;
+  const { title, tags, languages, roomAccessType } = roomData;
 
   const handleCopyRoomId = () => {
     if (window.navigator.clipboard) {
-      window.navigator.clipboard.writeText(roomShortUuid);
+      window.navigator.clipboard.writeText(window.location.href);
 
-      alert('방 번호가 복사되었습니다!');
+      alert('방 초대 링크가 복사되었습니다!');
     } else {
       alert('복사하기가 지원되지 않는 브라우저입니다.');
     }
@@ -30,7 +30,7 @@ export default function RoomInfoContainer({ className }: RoomInfoProps) {
     <div className={className}>
       <S.RoomIdWrapper className="roomId">
         <S.CopyRoomIdTag onClick={handleCopyRoomId}>
-          <S.TextId className="text">방 번호 복사</S.TextId>
+          <S.TextId className="text">초대 링크 복사</S.TextId>
           <Icon
             size="XXS"
             onClick={() => {}}

--- a/src/pages/RoomPage/RoomHeader/RoomUpdateModal.tsx
+++ b/src/pages/RoomPage/RoomHeader/RoomUpdateModal.tsx
@@ -18,7 +18,7 @@ interface InputProps {
   password: string;
 }
 
-export default function ModalRoom({ onClose }: ModalRoomProps) {
+export default function RoomUpdateModal({ onClose }: ModalRoomProps) {
   const { theme } = useCustomTheme();
   const { roomData, setRoomData } = useRoomStore();
   const {

--- a/src/pages/RoomPage/RoomHeader/index.ts
+++ b/src/pages/RoomPage/RoomHeader/index.ts
@@ -1,3 +1,3 @@
 export { default as RoomHeaderButtons } from './RoomHeaderButtons';
 export { default as RoomHeaderInfo } from './RoomHeaderInfo';
-export { default as RoomHeaderModal } from './RoomHeaderModal';
+export { default as RoomUpdateModal } from './RoomUpdateModal';

--- a/src/pages/RoomPage/RoomHeader/index.ts
+++ b/src/pages/RoomPage/RoomHeader/index.ts
@@ -1,3 +1,3 @@
-export { default as ModalRoom } from './ModalRoom';
 export { default as RoomHeaderButtons } from './RoomHeaderButtons';
 export { default as RoomHeaderInfo } from './RoomHeaderInfo';
+export { default as RoomHeaderModal } from './RoomHeaderModal';

--- a/src/pages/RoomPage/RoomPage.style.ts
+++ b/src/pages/RoomPage/RoomPage.style.ts
@@ -21,7 +21,8 @@ export const WaitingRoomContainer = styled(Col)`
 export const ChatContainer = styled(Col)<{ className: string }>`
   ${({ theme }) => css`
     flex-grow: 1;
-    min-width: 30rem;
+    min-width: 40rem;
+    max-width: 50rem;
     padding: 0 1rem;
     overflow: auto;
     border-left: 1px solid ${theme.color.transparent_30};

--- a/src/pages/RoomPage/RoomPage.style.ts
+++ b/src/pages/RoomPage/RoomPage.style.ts
@@ -6,7 +6,8 @@ import { Col, Row } from '@/styles/GlobalStyle';
 export const RoomContainer = styled(Row)`
   height: 100vh;
   padding: 3rem 0rem 3rem 5rem;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
 `;
 
 export const WaitingRoomContainer = styled(Col)`

--- a/src/pages/RoomPage/RoomPage.tsx
+++ b/src/pages/RoomPage/RoomPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import { Chat, Spinner } from '@/components';
@@ -50,6 +50,8 @@ export default function RoomPage() {
     refetch: refetchRoom,
   } = useGetUuidRoom(roomShortUuid);
 
+  const roomDataMemoized = useMemo(() => data, [data?.response]);
+
   useEffect(() => {
     connect(roomShortUuid);
     refetchMyInfo();
@@ -76,7 +78,7 @@ export default function RoomPage() {
     if (myInfo && data?.response) {
       setRoomData(data.response);
     }
-  }, [myInfo, data, listeners, receiveLogs]);
+  }, [myInfo, roomDataMemoized, listeners, receiveLogs]);
 
   useEffect(() => {
     if (!myInfo) return;

--- a/src/pages/RoomPage/RoomPage.tsx
+++ b/src/pages/RoomPage/RoomPage.tsx
@@ -22,6 +22,7 @@ export default function RoomPage() {
     setRoomData,
     reset: resetRoom,
   } = useRoomStore();
+
   const {
     client,
     subscription,
@@ -29,6 +30,7 @@ export default function RoomPage() {
     listeners,
     connect,
     disconnect,
+    setMessageValue,
     reset: resetMessage,
   } = useMessageStore();
 
@@ -66,7 +68,7 @@ export default function RoomPage() {
   useEffect(() => {
     refetchRoom();
     if (receiveLogs.at(-1) === SOCKET_TYPE.ROOM.START_CODING) {
-      console.log(receiveLogs);
+      setMessageValue({ messageLogs: [] });
       navigate(`${PATH.PROBLEMSOLVE}/${roomShortUuid}`, { replace: true });
     }
 

--- a/src/pages/RoomPage/RoomPage.tsx
+++ b/src/pages/RoomPage/RoomPage.tsx
@@ -67,6 +67,7 @@ export default function RoomPage() {
 
   useEffect(() => {
     refetchRoom();
+
     if (receiveLogs.at(-1) === SOCKET_TYPE.ROOM.START_CODING) {
       setMessageValue({ messageLogs: [] });
       navigate(`${PATH.PROBLEMSOLVE}/${roomShortUuid}`, { replace: true });

--- a/src/pages/RoomPage/TestInfo/TestInfo.tsx
+++ b/src/pages/RoomPage/TestInfo/TestInfo.tsx
@@ -83,11 +83,7 @@ export default function TestInfo({ className }: TestInfoProps) {
                 >
                   <AttachmentRounded />
                 </Icon>
-                {!problemLink ? (
-                  <span>문제를 설정해주세요</span>
-                ) : (
-                  <span>{problemLink.split('/').pop()}</span>
-                )}
+                {!problemLink && <span>문제를 설정해주세요</span>}
               </span>
             </td>
           </tr>

--- a/src/store/MessageStore/index.ts
+++ b/src/store/MessageStore/index.ts
@@ -37,6 +37,7 @@ const useMessageStore = create<MessageStoreState>()(
           connectHeaders: {
             Authorization: `Bearer ${localStorage.getItem(LOCAL_ACCESSTOKEN)}`,
           },
+          reconnectDelay: 3000,
         });
 
         stompClient.onConnect = () => {

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -54,6 +54,7 @@ export const GlobalStyle = createGlobalStyle`
 
   ::-webkit-scrollbar {
     width: 1rem;
+    height: 1rem;
   }
 
   ::-webkit-scrollbar-track {
@@ -82,6 +83,16 @@ export const GlobalStyle = createGlobalStyle`
   &::-webkit-scrollbar-button:vertical:end {
     display: block;
     height: 0.3rem;
+  }
+
+  &::-webkit-scrollbar-button:horizontal:start {
+    display: block;
+    width: 0.2rem;
+  }
+
+  &::-webkit-scrollbar-button:horizontal:end {
+    display: block;
+    width: 0.2rem;
   }
 
   textarea::-webkit-scrollbar {


### PR DESCRIPTION
## 📝 설명
RoomPage 1차 배포 테스트 피드백을 적용합니다.

## 💡 참고사항
`GlobalStyle.ts` : 가로 스크롤에 대한 CSS 속성을 추가했습니다.

## ✅ 이슈 유형
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [x] 기타

## 💻 작업 내용
- [x] ChatContainer 스타일 수정
긴 코드를 입력하면 ChatContainer의 width가 넓어진다.
`해결` max-width 적용
- [x] quit 2번 뜨는 이슈
`해결` PSHeader sendMessage(quit) 37번줄 삭제
- [x] 채팅창에 입장, 퇴장한 멤버의 Avatar, nickname이 안 보이는 이슈
`원인` 퇴장한 멤버는 roomData에서 사라지기 때문에 nickname을 구하지 못하고 있다. roomData를 참조하지 않고 state를 사용하면 해결된다. 하지만, 여전히 입장은 roomData가 없기 때문에 값을 가져올 수 있는 방법이 없다. 입, 퇴장 시 profileImage와 Avatar를 보여주지 않는다.
- [x] 방 정보 수정을 하면 멤버는 ready하지 않을 경우 안 바뀌는 이슈
- [x] ProblemSolve, ProblemShare 페이지에서도 새로고침 해도 소켓 연결이 재접속 되게끔 수정
- [x] 채팅 컴포넌트-메시지 부분에 유저 기본 이미지 적용되던 이슈

## 💬 etc