### PR TITLE
[🐛fix]: Chat 컴포넌트 채팅 메세지 중복 출력 이슈 해결

### DIFF
--- a/src/components/Common/Chat/Chat.tsx
+++ b/src/components/Common/Chat/Chat.tsx
@@ -22,7 +22,7 @@ interface MessageState extends Required<T.Message> {
 export default function Chat({ height = '100%' }: ChatProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  const { messageLogs, receiveLogs } = useMessageStore();
+  const { messageLogs } = useMessageStore();
 
   const {
     roomData: { roomMembers },
@@ -62,7 +62,7 @@ export default function Chat({ height = '100%' }: ChatProps) {
     const newMessage = messageLogs.at(-1);
     const newLogs = newMessage && memberIdToData(newMessage.memberId);
     newLogs && setMessageList(newLogs);
-  }, [messageLogs, receiveLogs]);
+  }, [messageLogs]);
 
   return (
     <S.ChatContainer $height={height}>


### PR DESCRIPTION
## 📝 설명
Chat 컴포넌트의 이슈를 해결합니다.

`문제 상황`
채팅을 입력한 상태에서 준비 버튼을 누르면 마지막 채팅 내용이 중복 출력되는 이슈 해결했습니다.

## ✅ PR 유형
- [x] 기타

## 💻 작업 내용
- [x] 마지막 채팅 내용 중복 출력 되는 이슈 해결
`원인` 의존성 배열에 receiveLogs가 있어 준비를 했을 때에도 채팅이 출력되었습니다.

## 💬 PR 포인트
- hotfix로 별도 이슈를 생성하지 않았습니다.
- 한 줄 수정이므로 빠른 approve 부탁드립니다.