### PR TITLE
[✨feat]: 내 오디오 선택 기능 추가

### DIFF
--- a/src/components/Common/Audio/AudioMenu.tsx
+++ b/src/components/Common/Audio/AudioMenu.tsx
@@ -70,7 +70,7 @@ const AudioMenu = ({ audioStream, audioDevices, onChange }: AudioMenuProps) => {
         <FormControl>
           <RadioGroup
             aria-labelledby="devices-radio-group"
-            value={selectedAudio.deviceId}
+            value={selectedAudio?.deviceId}
             name="devices"
             onChange={handleChangeDevice}
             sx={{
@@ -87,7 +87,7 @@ const AudioMenu = ({ audioStream, audioDevices, onChange }: AudioMenuProps) => {
                   value={device.deviceId}
                   control={<Radio />}
                   label={device.label}
-                  checked={device.label === selectedAudio.label}
+                  checked={device.label === selectedAudio?.label}
                   sx={{
                     '& .MuiTypography-root': {
                       fontSize: 14,

--- a/src/components/Common/Audio/AudioMenu.tsx
+++ b/src/components/Common/Audio/AudioMenu.tsx
@@ -1,0 +1,108 @@
+import { Icon } from '@/components';
+import { useCustomTheme } from '@/hooks/useCustomTheme';
+import { KeyboardArrowDownRounded } from '@mui/icons-material';
+import {
+  FormControl,
+  FormControlLabel,
+  Popover,
+  Radio,
+  RadioGroup,
+} from '@mui/material';
+import { useState } from 'react';
+
+interface AudioMenuProps {
+  audioStream: MediaStream;
+  audioDevices: any[];
+  onChange: (deviceId: string) => Promise<void>;
+}
+
+const AudioMenu = ({ audioStream, audioDevices, onChange }: AudioMenuProps) => {
+  const { theme } = useCustomTheme();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [selectedAudio, setSelectedAudio] = useState(() => {
+    const myAudio = audioStream.getTracks()[0].label;
+    return audioDevices.find(device => device.label === myAudio);
+  });
+
+  const handleOpenPopover = (e: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(e.currentTarget);
+  };
+
+  const handlePopoverClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleChangeDevice = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedAudio(
+      audioDevices.find(device => device.deviceId === e.target.value)
+    );
+    onChange(e.target.value);
+  };
+
+  return (
+    <>
+      <Icon
+        aria-describedby="change-device"
+        backgroundSize="XXS"
+        background={true}
+        onClick={handleOpenPopover}
+      >
+        <KeyboardArrowDownRounded />
+      </Icon>
+      <Popover
+        id="change-device"
+        open={anchorEl ? true : false}
+        anchorEl={anchorEl}
+        onClose={handlePopoverClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+        sx={{
+          marginTop: '1rem',
+        }}
+      >
+        <FormControl>
+          <RadioGroup
+            aria-labelledby="devices-radio-group"
+            value={selectedAudio.deviceId}
+            name="devices"
+            onChange={handleChangeDevice}
+            sx={{
+              padding: '1rem 1.5rem',
+              '&:MuiTypography-root': {
+                fontSize: 30,
+              },
+            }}
+          >
+            {audioDevices?.map(device => {
+              return (
+                <FormControlLabel
+                  key={device.deviceId}
+                  value={device.deviceId}
+                  control={<Radio />}
+                  label={device.label}
+                  checked={device.label === selectedAudio.label}
+                  sx={{
+                    '& .MuiTypography-root': {
+                      fontSize: 14,
+                    },
+                    '&:hover': {
+                      color: theme.color.gray_50,
+                    },
+                  }}
+                />
+              );
+            })}
+          </RadioGroup>
+        </FormControl>
+      </Popover>
+    </>
+  );
+};
+
+export default AudioMenu;

--- a/src/components/Common/Audio/AudioMenu.tsx
+++ b/src/components/Common/Audio/AudioMenu.tsx
@@ -12,7 +12,7 @@ import { useState } from 'react';
 
 interface AudioMenuProps {
   audioStream: MediaStream;
-  audioDevices: any[];
+  audioDevices: MediaDeviceInfo[];
   onChange: (deviceId: string) => Promise<void>;
 }
 

--- a/src/components/Common/Audio/AudioMenu.tsx
+++ b/src/components/Common/Audio/AudioMenu.tsx
@@ -1,5 +1,3 @@
-import { Icon } from '@/components';
-import { useCustomTheme } from '@/hooks/useCustomTheme';
 import { KeyboardArrowDownRounded } from '@mui/icons-material';
 import {
   FormControl,
@@ -9,6 +7,9 @@ import {
   RadioGroup,
 } from '@mui/material';
 import { useState } from 'react';
+
+import { Icon } from '@/components';
+import { useCustomTheme } from '@/hooks/useCustomTheme';
 
 interface AudioMenuProps {
   audioStream: MediaStream;

--- a/src/components/Common/Audio/MyAudio.style.ts
+++ b/src/components/Common/Audio/MyAudio.style.ts
@@ -1,0 +1,6 @@
+import { Row } from '@/styles/GlobalStyle';
+import { styled } from 'styled-components';
+
+export const MyAudioWrapper = styled(Row)`
+  gap: 1rem;
+`;

--- a/src/components/Common/Audio/MyAudio.tsx
+++ b/src/components/Common/Audio/MyAudio.tsx
@@ -31,7 +31,7 @@ export default function MyAudio({ memberId }: MyAudioProps) {
       roomShortUuid,
     });
 
-  const getAudioDevices = async () => {
+  const getAvailableDevices = async () => {
     return await navigator.mediaDevices.enumerateDevices();
   };
 
@@ -56,7 +56,7 @@ export default function MyAudio({ memberId }: MyAudioProps) {
       stream.getAudioTracks()[0].enabled = true;
       setAudioStream(stream);
 
-      const devices = await getAudioDevices();
+      const devices = await getAvailableDevices();
       const audioList = devices.filter(
         device =>
           device.kind === 'audioinput' && device.deviceId !== 'communications'

--- a/src/components/Common/Audio/MyAudio.tsx
+++ b/src/components/Common/Audio/MyAudio.tsx
@@ -3,8 +3,10 @@ import { useEffect, useState } from 'react';
 import { useAudioSocket } from '@/hooks/Audio/useAudioSocket';
 import useRoomStore from '@/store/RoomStore';
 
-import Tooltip from '../Tooltip/Tooltip';
 import Audio from './Audio';
+import AudioMenu from './AudioMenu';
+import { MyAudioWrapper } from './MyAudio.style';
+import { Tooltip } from '@/components';
 
 interface MyAudioProps {
   memberId: number;
@@ -14,21 +16,35 @@ export default function MyAudio({ memberId }: MyAudioProps) {
   const key = memberId.toString();
 
   const [audioStream, setAudioStream] = useState<MediaStream | null>(null);
+  const [audioDevices, setAudioDevices] = useState<MediaDeviceInfo[] | null>(
+    null
+  );
   const [isActive, setIsActive] = useState(true);
 
   const {
     roomData: { roomShortUuid },
   } = useRoomStore();
 
-  const { client, connectSocket, disconnectSocket } = useAudioSocket({
-    myKey: key,
-    roomShortUuid,
-  });
+  const { client, connectSocket, disconnectSocket, replaceTrack } =
+    useAudioSocket({
+      myKey: key,
+      roomShortUuid,
+    });
 
-  const openMediaDevices = async () => {
+  const getAudioDevices = async () => {
+    return await navigator.mediaDevices.enumerateDevices();
+  };
+
+  const openMediaDevices = async (deviceId?: string) => {
     console.log('socket flow: 1. getUserMedia 나는', memberId, '번 유저');
     return await navigator.mediaDevices.getUserMedia({
-      audio: true,
+      audio: deviceId
+        ? {
+            deviceId: {
+              exact: deviceId,
+            },
+          }
+        : true,
     });
   };
 
@@ -39,6 +55,15 @@ export default function MyAudio({ memberId }: MyAudioProps) {
       // 진입 시 음소거 설정
       stream.getAudioTracks()[0].enabled = true;
       setAudioStream(stream);
+
+      const devices = await getAudioDevices();
+      const audioList = devices.filter(
+        device =>
+          device.kind === 'audioinput' && device.deviceId !== 'communications'
+      );
+
+      setAudioDevices(audioList);
+
       // socket 연결
       console.log('---1. connect ---', stream);
       connectSocket(stream);
@@ -71,20 +96,40 @@ export default function MyAudio({ memberId }: MyAudioProps) {
     };
   }, []);
 
+  const handleChangeDevice = async (deviceId: string) => {
+    try {
+      const stream = await openMediaDevices(deviceId);
+      replaceTrack(stream);
+    } catch (error) {
+      console.error('media 변경에 실패했습니다.', error);
+    }
+  };
+
   return (
-    <Tooltip
-      text={audioStream?.getTracks()[0].label ?? '선택된 마이크가 없습니다'}
-    >
-      <div>
-        <Audio
-          memberId={key}
-          isMyAudio
+    <MyAudioWrapper>
+      <Tooltip
+        text={
+          audioStream?.getTracks()[0].label ? '' : '선택된 마이크가 없습니다'
+        }
+      >
+        <div>
+          <Audio
+            memberId={key}
+            isMyAudio
+            audioStream={audioStream}
+            isActive={isActive}
+            onIconClick={handleIconClick}
+            connectSocket={connectSocket}
+          />
+        </div>
+      </Tooltip>
+      {audioDevices && audioStream && (
+        <AudioMenu
           audioStream={audioStream}
-          isActive={isActive}
-          onIconClick={handleIconClick}
-          connectSocket={connectSocket}
+          audioDevices={audioDevices}
+          onChange={handleChangeDevice}
         />
-      </div>
-    </Tooltip>
+      )}
+    </MyAudioWrapper>
   );
 }

--- a/src/components/Common/Audio/MyAudio.tsx
+++ b/src/components/Common/Audio/MyAudio.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 
+import { Tooltip } from '@/components';
 import { useAudioSocket } from '@/hooks/Audio/useAudioSocket';
 import useRoomStore from '@/store/RoomStore';
 
 import Audio from './Audio';
 import AudioMenu from './AudioMenu';
 import { MyAudioWrapper } from './MyAudio.style';
-import { Tooltip } from '@/components';
 
 interface MyAudioProps {
   memberId: number;

--- a/src/components/Common/Tooltip/Tooltip.tsx
+++ b/src/components/Common/Tooltip/Tooltip.tsx
@@ -7,6 +7,10 @@ interface TooltipProps {
 }
 
 export default function Tooltip({ children, text, ...props }: TooltipProps) {
+  if (!text) {
+    return children;
+  }
+
   return (
     <TooltipMui
       title={<span style={{ fontSize: 12 }}>{text}</span>}

--- a/src/hooks/Audio/useAudioSocket.ts
+++ b/src/hooks/Audio/useAudioSocket.ts
@@ -225,6 +225,19 @@ export const useAudioSocket = ({ myKey, roomShortUuid }: AudioSocketProps) => {
     return pc;
   };
 
+  const replaceTrack = (newStream: MediaStream) => {
+    const [audioTrack] = newStream.getAudioTracks();
+    console.log('replaceTrack() 변경할 audioTrack :', audioTrack.label);
+
+    pcListMap.current.forEach(pc => {
+      const senders = pc?.getSenders();
+      const audioSender = senders?.find(
+        sender => sender.track?.kind === audioTrack.kind
+      );
+      audioSender?.replaceTrack(audioTrack);
+    });
+  };
+
   const resetState = () => {
     console.log('reset');
 
@@ -253,5 +266,6 @@ export const useAudioSocket = ({ myKey, roomShortUuid }: AudioSocketProps) => {
     disconnectSocket,
     createOtherPeerConnection,
     sendOffer,
+    replaceTrack,
   };
 };


### PR DESCRIPTION
## 📝 설명
MyAudio.tsx에서 오디오 리스트를 보여주는 버튼을 생성
⚠️ Tooltip 리팩토링

## ✅ PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 💻 작업 내용
- [x] 현재 사용 가능한 오디오 리스트를 보여준다.(AudioMenu.tsx)
- [x] 사용자는 오디오를 변경할 수 있다.(MyAudio.tsx)
openMediaDevices()에 deviceId 매개변수를 추가하여 특정 기기에 연결할 수 있도록 한다.
- [x] 기타 :  툴팁 리팩토링
text가 빈 값인 경우 툴팁을 렌더링 하지 않습니다. 

## 💬 PR 포인트
- 일부 기기 변경 시 소리가 나지 않는 경우가 있습니다. 이 경우 하드웨어 문제일 수 있으니 다른 프로그램(예: discord)에서도 오디오 기기 테스트를 진행해주세요.
- 다른 작업에서도 track을 변경할 경우, useAudioSocket.ts의 replaceTrack()을 사용해주세요.
- AudioMenu에서 현재 기기를 확인할 수 있으므로 기존의 툴팁은 제외하였습니다. 기기가 없는 경우 툴팁이 활성화됩니다.