### PR TITLE
[✨feat]: 마이크 권한 설정 기능 추가

### DIFF
--- a/src/components/Common/Audio/Audio.tsx
+++ b/src/components/Common/Audio/Audio.tsx
@@ -79,7 +79,13 @@ export default function Audio({
       {isActive ? (
         <Icon
           onClick={onIconClick}
-          color={isSpeaking ? theme.color.green : ''}
+          color={
+            isSpeaking
+              ? theme.color.green
+              : audioStream
+                ? theme.color.gray_30
+                : theme.color.red
+          }
         >
           {isMyAudio ? <MicRounded /> : <VolumeUpRounded />}
         </Icon>

--- a/src/components/Common/Audio/Audio.tsx
+++ b/src/components/Common/Audio/Audio.tsx
@@ -1,4 +1,5 @@
 import { VolumeOffRounded, VolumeUpRounded } from '@mui/icons-material';
+import { MicOffRounded, MicRounded } from '@mui/icons-material';
 import { useEffect, useRef, useState } from 'react';
 
 import { Icon } from '@/components';
@@ -80,11 +81,11 @@ export default function Audio({
           onClick={onIconClick}
           color={isSpeaking ? theme.color.green : ''}
         >
-          <VolumeUpRounded />
+          {isMyAudio ? <MicRounded /> : <VolumeUpRounded />}
         </Icon>
       ) : (
         <Icon onClick={onIconClick}>
-          <VolumeOffRounded />
+          {isMyAudio ? <MicOffRounded /> : <VolumeOffRounded />}
         </Icon>
       )}
     </>

--- a/src/components/Common/Audio/Audio.tsx
+++ b/src/components/Common/Audio/Audio.tsx
@@ -66,7 +66,8 @@ export default function Audio({
     };
   }, [audioStream]);
 
-  if (!audioStream) return null;
+  // 상대 오디오가 연결되지 않은 경우 null 반환
+  if (!isMyAudio && !audioStream) return null;
 
   return (
     <>

--- a/src/components/Common/Audio/MyAudio.tsx
+++ b/src/components/Common/Audio/MyAudio.tsx
@@ -25,6 +25,7 @@ export default function MyAudio({ memberId }: MyAudioProps) {
     roomShortUuid,
   });
 
+  // 마이크 권한 설정
   const openMediaDevices = async () => {
     console.log('socket flow: 1. getUserMedia 나는', memberId, '번 유저');
     return await navigator.mediaDevices.getUserMedia({
@@ -47,10 +48,33 @@ export default function MyAudio({ memberId }: MyAudioProps) {
     }
   };
 
+  // 마이크 권한 확인
+  const checkPermission = async () => {
+    const permission = await navigator.permissions.query({
+      name: 'microphone' as PermissionName,
+    });
+
+    // 진입 시 무조건 startAudio 호출
+    // 마이크 권한이 없는 경우 getUserMedia을 호출해야 권한 설정 아이콘이 활성화됨
+    startAudio();
+
+    // 웹 상에서 권한 변경시 이벤트 발생
+    permission.onchange = () => {
+      switch (permission.state) {
+        case 'granted': {
+          if (audioStream === null) {
+            startAudio();
+          }
+          break;
+        }
+      }
+    };
+  };
+
   // 마이크 버튼 클릭 시 음소거 설정 및 해제
   const handleIconClick = () => {
     if (audioStream === null) {
-      startAudio();
+      checkPermission();
     }
 
     if (audioStream === null) return;
@@ -62,7 +86,7 @@ export default function MyAudio({ memberId }: MyAudioProps) {
   };
 
   useEffect(() => {
-    startAudio();
+    checkPermission();
 
     return () => {
       if (client !== null) return;

--- a/src/components/Common/Audio/MyAudio.tsx
+++ b/src/components/Common/Audio/MyAudio.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { useAudioSocket } from '@/hooks/Audio/useAudioSocket';
 import useRoomStore from '@/store/RoomStore';
+import { toastify } from '@/utils/toastify';
 
 import Tooltip from '../Tooltip/Tooltip';
 import Audio from './Audio';
@@ -45,7 +46,13 @@ export default function MyAudio({ memberId }: MyAudioProps) {
       connectSocket(stream);
     } catch (error) {
       console.error('Error accessing media devices.', error);
+      toastify.error('마이크 권한을 허용해 주세요');
     }
+  };
+
+  const endAudio = () => {
+    disconnectSocket();
+    setAudioStream(null);
   };
 
   // 마이크 권한 확인
@@ -66,6 +73,10 @@ export default function MyAudio({ memberId }: MyAudioProps) {
             startAudio();
           }
           break;
+        }
+        case 'denied': {
+          endAudio();
+          toastify.error('마이크 권한을 허용해 주세요');
         }
       }
     };
@@ -91,7 +102,7 @@ export default function MyAudio({ memberId }: MyAudioProps) {
     return () => {
       if (client !== null) return;
       console.log('unmount client', client);
-      disconnectSocket();
+      endAudio();
     };
   }, []);
 


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->

마이크 **권한을 재설정하고 권한 변경을 감지**하는 기능을 추가하였습니다.
본인의 마이크와 상대의 마이크를 구분하기 위해 아이콘의 **상태에 따라 UI와 색상을 변경**하였습니다.

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 💻 작업 내용

<!-- PR 본문을 입력하세요. -->

### 권한 재설정
  - 마이크 권한 허용 시 socket 통신을 시작합니다.
  - 마이크 권한 거부 시 마이크 버튼을 누르면 **권한 설정을 요청하는 토스트**를 띄웁니다.
  - 마이크 권한 거부 시 **상태를 초기화**합니다. socket 통신이 해제되고 audioStream을 null로 설정합니다.

### 음성 아이콘 구분
  - **나의 음성 아이콘은 마이크 모양**, **상대의 아이콘 모양은 스피커 모양**으로 아이콘을 구분하였습니다.
  - 상대방이 권한 거부 등으로 socket 연결이 되어있지 않으면 **아이콘을 표시하지 않습니다.**
  - 색상을 상태에 따라 변경했습니다.
    - 초록색: 말하고 있는 상태
    - 회색: 말하고 있지 않는 상태
    - 빨간색: 권한이 허용되지 않은 상태 

## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->

- 지금은 권한이 허용된 상태로 **입장한 뒤 권한 거부**를 했을 때 본인의 마이크만 연결 해제되고 **상대방의 음성은 들리는 상태**입니다.
- 혹시 권한 거부를 했을 때 연결되었던 상대방의 음성 정보들도 제거하는게 자연스러울까요? 아니면 지금처럼 상대방의 음성은 들을 수 있게 하는게 자연스러울지 의견 궁금합니다!