### PR TITLE
[✨feat]: 본인 마이크 음소거 기능 추가

### DIFF
--- a/src/components/Common/Audio/Audio.tsx
+++ b/src/components/Common/Audio/Audio.tsx
@@ -78,11 +78,17 @@ export default function Audio({
         <Icon
           onClick={onIconClick}
           color={isSpeaking ? theme.color.green : ''}
+          style={{
+            cursor: isMyAudio ? 'pointer' : '',
+          }}
         >
           <VolumeUpRounded />
         </Icon>
       ) : (
-        <Icon onClick={onIconClick}>
+        <Icon
+          onClick={onIconClick}
+          style={{ cursor: isMyAudio ? 'pointer' : '' }}
+        >
           <VolumeOffRounded />
         </Icon>
       )}

--- a/src/hooks/Audio/useAudioSocket.ts
+++ b/src/hooks/Audio/useAudioSocket.ts
@@ -243,6 +243,18 @@ export const useAudioSocket = ({ myKey, roomShortUuid }: AudioSocketProps) => {
     client.current?.deactivate();
     resetState();
   };
+  // 새로운 audioStream을 pc list에 적용하는 함수
+  const replaceTrack = (newStream: MediaStream) => {
+    const [audioTrack] = newStream.getAudioTracks();
+
+    pcListMap.current.forEach(pc => {
+      const senders = pc?.getSenders();
+      const audioSender = senders?.find(
+        sender => sender.track?.kind === audioTrack.kind
+      );
+      audioSender?.replaceTrack(audioTrack);
+    });
+  };
 
   return {
     isConnected,
@@ -253,5 +265,6 @@ export const useAudioSocket = ({ myKey, roomShortUuid }: AudioSocketProps) => {
     disconnectSocket,
     createOtherPeerConnection,
     sendOffer,
+    replaceTrack,
   };
 };

--- a/src/hooks/Audio/useAudioSocket.ts
+++ b/src/hooks/Audio/useAudioSocket.ts
@@ -225,19 +225,6 @@ export const useAudioSocket = ({ myKey, roomShortUuid }: AudioSocketProps) => {
     return pc;
   };
 
-  const replaceTrack = (newStream: MediaStream) => {
-    const [audioTrack] = newStream.getAudioTracks();
-    console.log('replaceTrack() 변경할 audioTrack :', audioTrack.label);
-
-    pcListMap.current.forEach(pc => {
-      const senders = pc?.getSenders();
-      const audioSender = senders?.find(
-        sender => sender.track?.kind === audioTrack.kind
-      );
-      audioSender?.replaceTrack(audioTrack);
-    });
-  };
-
   const resetState = () => {
     console.log('reset');
 


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->
Room page에 접속 시 마이크 **음소거를 기본값**으로 설정하고 이후 마이크 **음소거** 여부를 아이콘을 클릭해 변경할 수 있게 구현했습니다.

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가

## 💻 작업 내용

<!-- PR 본문을 입력하세요. -->
### 초기 접속 시 마이크 음소거
- 방에 처음 접속했을 때는 마이크 음소거가 기본값이 되도록 설정했습니다.
- 음소거 상태에 맞게 아이콘도 음소거 아이콘이 되도록 state 기본값을 변경했습니다. (https://github.com/1e5i-Shark/algobaro-fe/commit/4b9acb2b0ea1ec289e04ce4deb9d98a93b7560f9)

### 본인 마이크 아이콘 클릭 시 음소거 상대 변경
- 아이콘을 클릭해 마이크 음소거 상태를 변경하면 audioStream에도 적용되도록 `useAudioSocket` 훅 내 `replaceTrack` 함수를 추가했습니다. (https://github.com/1e5i-Shark/algobaro-fe/commit/c3f2f21323be185421fb48b9359d7c2b48c3a3a5)

## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
- 본인 마이크 음소거 여부를 상대방도 볼 수 있도록 구현해보려고 했으나 계속해서 `enabled` 상태가 인식되지 않는 것 같습니다.
  - 6.25 (화) 까지 필수 기능들을 취합해야 할 것 같아 일단 음소거 기능까지만 완성된 버전까지 PR을 작성합니다. 이후 따로 해당 기능을 추가하겠습니다.
- 방 접속 시 초기 마이크를 음소거로 기본값으로 변경했는데 다른 분들의 의견도 동일한지 궁금합니다.
